### PR TITLE
fix(behaviors): implement per-key stampede prevention in idempotency guard

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
@@ -11,7 +11,8 @@ namespace Qorpe.Mediator.Behaviors.Behaviors;
 
 /// <summary>
 /// Pipeline behavior that prevents duplicate command execution using idempotency keys.
-/// Queries are automatically skipped. Concurrent requests: first executes, second waits.
+/// Queries are automatically skipped. Concurrent requests with the same key are serialized
+/// via per-key locking to prevent duplicate handler execution.
 /// </summary>
 public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
@@ -19,7 +20,9 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
     private readonly IIdempotencyStore? _store;
     private readonly ILogger<IdempotencyBehavior<TRequest, TResponse>> _logger;
     private readonly IdempotencyBehaviorOptions _options;
-    private static readonly SemaphoreSlim KeyLock = new(1, 1);
+
+    // Per-key lock pool shared across all IdempotencyBehavior instances
+    private static readonly BoundedLockPool KeyLocks = new();
 
     public IdempotencyBehavior(
         ILogger<IdempotencyBehavior<TRequest, TResponse>> logger,
@@ -69,9 +72,12 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
         var idempotencyKey = GenerateKey(request);
         var window = TimeSpan.FromSeconds(idempotentAttr.WindowSeconds);
 
+        // Per-key lock: concurrent requests with the same idempotency key are serialized
+        var keyLock = KeyLocks.GetOrCreate(idempotencyKey);
+        await keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // Check if already processed
+            // Check if already processed (inside lock to prevent race conditions)
             if (await _store.ExistsAsync(idempotencyKey, cancellationToken).ConfigureAwait(false))
             {
                 var cached = await _store.GetAsync<TResponse>(idempotencyKey, cancellationToken).ConfigureAwait(false);
@@ -97,6 +103,10 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
             _logger.LogWarning(ex, "Idempotent request {RequestName} failed, not caching", typeof(TRequest).Name);
             await _store.RemoveAsync(idempotencyKey, cancellationToken).ConfigureAwait(false);
             throw;
+        }
+        finally
+        {
+            keyLock.Release();
         }
     }
 

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/IdempotencyBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/IdempotencyBehaviorTests.cs
@@ -128,4 +128,86 @@ public class IdempotencyBehaviorTests
         await behavior.Handle(new IdempotentCommand("data"), next, CancellationToken.None);
         await store.DidNotReceive().ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Should_Serialize_Concurrent_Requests_With_Same_Key()
+    {
+        var executionCount = 0;
+        var store = new InMemoryIdempotencyStore();
+
+        var behavior = new IdempotencyBehavior<IdempotentCommand, Result>(_logger, _options, store);
+
+        RequestHandlerDelegate<Result> next = async () =>
+        {
+            Interlocked.Increment(ref executionCount);
+            await Task.Delay(50); // Simulate work
+            return Result.Success();
+        };
+
+        var request = new IdempotentCommand("same-data");
+
+        // Launch concurrent requests with the same idempotency key
+        var tasks = Enumerable.Range(0, 10).Select(_ =>
+            behavior.Handle(request, next, CancellationToken.None).AsTask());
+
+        await Task.WhenAll(tasks);
+
+        // Only the first should have executed the handler; rest should get cached result
+        executionCount.Should().Be(1, "per-key lock should serialize concurrent identical requests");
+    }
+
+    [Fact]
+    public async Task Should_Allow_Parallel_Execution_For_Different_Keys()
+    {
+        var executionCount = 0;
+        var store = new InMemoryIdempotencyStore();
+
+        var behavior = new IdempotencyBehavior<IdempotentCommand, Result>(_logger, _options, store);
+
+        RequestHandlerDelegate<Result> next = () =>
+        {
+            Interlocked.Increment(ref executionCount);
+            return new ValueTask<Result>(Result.Success());
+        };
+
+        // Different keys should not block each other
+        var tasks = Enumerable.Range(0, 10).Select(i =>
+            behavior.Handle(new IdempotentCommand($"data-{i}"), next, CancellationToken.None).AsTask());
+
+        await Task.WhenAll(tasks);
+
+        executionCount.Should().Be(10, "different idempotency keys should execute independently");
+    }
+}
+
+/// <summary>
+/// Simple in-memory idempotency store for testing concurrent behavior.
+/// </summary>
+internal sealed class InMemoryIdempotencyStore : IIdempotencyStore
+{
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, object> _store = new();
+
+    public ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
+        => new(_store.ContainsKey(key));
+
+    public ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (_store.TryGetValue(key, out var value) && value is T typed)
+        {
+            return new(typed);
+        }
+        return new(default(T));
+    }
+
+    public ValueTask SetAsync<T>(string key, T value, TimeSpan expiry, CancellationToken cancellationToken = default)
+    {
+        _store[key] = value!;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        _store.TryRemove(key, out _);
+        return ValueTask.CompletedTask;
+    }
 }


### PR DESCRIPTION
## What

Replace unused global `SemaphoreSlim` with per-key locking via `BoundedLockPool` in `IdempotencyBehavior`. Concurrent requests with the same idempotency key are now properly serialized.

## Why

The previous implementation defined a `SemaphoreSlim` field but never acquired it. This meant concurrent identical requests could both pass the `ExistsAsync` check, both execute the handler, and both store results — defeating the purpose of idempotency.

## Changes

- **`IdempotencyBehavior`** — wrap check-execute-store in per-key `BoundedLockPool` lock with proper `finally` release
- **2 new unit tests** — concurrent same-key serialization (only 1 execution), parallel different-key independence (all execute)
- **`InMemoryIdempotencyStore`** — test helper for real concurrent testing (vs mocks)

## Related Issues

Closes #3

## Test Results

- Unit: 132 passed
- Integration: 21 passed
- Load: 18 passed
- **Total: 171 passed, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Added tests for new functionality