### PR TITLE
fix(core): apply pipeline behaviors to streaming request execution

### DIFF
--- a/src/Qorpe.Mediator/Abstractions/IStreamPipelineBehavior.cs
+++ b/src/Qorpe.Mediator/Abstractions/IStreamPipelineBehavior.cs
@@ -1,0 +1,29 @@
+namespace Qorpe.Mediator.Abstractions;
+
+/// <summary>
+/// Delegate representing the next step in the stream pipeline.
+/// Returns the async enumerable stream from the handler or next behavior.
+/// </summary>
+/// <typeparam name="TResponse">The type of each item in the stream.</typeparam>
+public delegate IAsyncEnumerable<TResponse> StreamHandlerDelegate<out TResponse>();
+
+/// <summary>
+/// Pipeline behavior for streaming requests. Wraps the stream creation,
+/// enabling pre-stream checks (authorization, validation) and post-stream
+/// operations (audit logging).
+/// </summary>
+/// <typeparam name="TRequest">The stream request type.</typeparam>
+/// <typeparam name="TResponse">The type of each item in the stream.</typeparam>
+public interface IStreamPipelineBehavior<in TRequest, TResponse>
+    where TRequest : IStreamRequest<TResponse>
+{
+    /// <summary>
+    /// Handles the stream request within the pipeline. Call <paramref name="next"/>
+    /// to invoke the next behavior or the stream handler.
+    /// </summary>
+    /// <param name="request">The stream request.</param>
+    /// <param name="next">Delegate to the next behavior or handler.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The async enumerable stream.</returns>
+    IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
+}

--- a/src/Qorpe.Mediator/DependencyInjection/AssemblyScanner.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/AssemblyScanner.cs
@@ -14,6 +14,7 @@ internal static class AssemblyScanner
         typeof(INotificationHandler<>),
         typeof(IStreamRequestHandler<,>),
         typeof(IPipelineBehavior<,>),
+        typeof(IStreamPipelineBehavior<,>),
         typeof(IRequestPreProcessor<>),
         typeof(IRequestPostProcessor<,>)
     };

--- a/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
+++ b/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
@@ -221,7 +221,8 @@ internal abstract class StreamHandlerWrapperBase
 }
 
 /// <summary>
-/// Typed stream handler wrapper. Zero reflection.
+/// Typed stream handler wrapper. Resolves handler and stream pipeline behaviors from DI.
+/// Behaviors wrap the stream creation, enabling pre-stream checks and post-stream operations.
 /// </summary>
 internal sealed class StreamHandlerWrapper<TRequest, TResponse> : StreamHandlerWrapperBase
     where TRequest : IStreamRequest<TResponse>
@@ -235,7 +236,47 @@ internal sealed class StreamHandlerWrapper<TRequest, TResponse> : StreamHandlerW
             throw new HandlerNotFoundException(typeof(TRequest));
         }
 
-        await foreach (var item in handler.Handle((TRequest)request, cancellationToken).ConfigureAwait(false))
+        var typedRequest = (TRequest)request;
+
+        // Resolve stream pipeline behaviors
+        var behaviors = serviceProvider.GetService<IEnumerable<IStreamPipelineBehavior<TRequest, TResponse>>>();
+
+        IAsyncEnumerable<TResponse> stream;
+
+        if (behaviors is null)
+        {
+            stream = handler.Handle(typedRequest, cancellationToken);
+        }
+        else
+        {
+            // Materialize behaviors
+            var behaviorArray = behaviors is IStreamPipelineBehavior<TRequest, TResponse>[] arr
+                ? arr
+                : behaviors is ICollection<IStreamPipelineBehavior<TRequest, TResponse>> col
+                    ? col.ToArray()
+                    : behaviors.ToArray();
+
+            if (behaviorArray.Length == 0)
+            {
+                stream = handler.Handle(typedRequest, cancellationToken);
+            }
+            else
+            {
+                // Build pipeline chain — innermost is the handler
+                StreamHandlerDelegate<TResponse> next = () => handler.Handle(typedRequest, cancellationToken);
+
+                for (int i = behaviorArray.Length - 1; i >= 0; i--)
+                {
+                    var behavior = behaviorArray[i];
+                    var currentNext = next;
+                    next = () => behavior.Handle(typedRequest, currentNext, cancellationToken);
+                }
+
+                stream = next();
+            }
+        }
+
+        await foreach (var item in stream.ConfigureAwait(false))
         {
             yield return item;
         }

--- a/tests/Qorpe.Mediator.UnitTests/Core/MediatorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Core/MediatorTests.cs
@@ -153,6 +153,96 @@ public class MediatorStreamTests
         await act.Should().ThrowAsync<OperationCanceledException>();
         items.Count.Should().BeGreaterThanOrEqualTo(3);
     }
+
+    [Fact]
+    public async Task CreateStream_WithBehavior_ShouldExecuteBehavior()
+    {
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestStreamRequest).Assembly));
+        var trackingBehavior = new TrackingStreamBehavior<TestStreamRequest, int>();
+        services.AddSingleton<IStreamPipelineBehavior<TestStreamRequest, int>>(trackingBehavior);
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var items = new List<int>();
+        await foreach (var item in mediator.CreateStream(new TestStreamRequest(3)))
+        {
+            items.Add(item);
+        }
+
+        items.Should().HaveCount(3);
+        trackingBehavior.WasExecuted.Should().BeTrue("stream pipeline behavior should execute");
+    }
+
+    [Fact]
+    public async Task CreateStream_WithBlockingBehavior_ShouldPreventStreaming()
+    {
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestStreamRequest).Assembly));
+        services.AddSingleton<IStreamPipelineBehavior<TestStreamRequest, int>>(
+            new BlockingStreamBehavior<TestStreamRequest, int>());
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var items = new List<int>();
+        var act = async () =>
+        {
+            await foreach (var item in mediator.CreateStream(new TestStreamRequest(5)))
+            {
+                items.Add(item);
+            }
+        };
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        items.Should().BeEmpty("blocking behavior should prevent any items from being yielded");
+    }
+
+    [Fact]
+    public async Task CreateStream_WithoutBehavior_ShouldStillWork()
+    {
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestStreamRequest).Assembly));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var items = new List<int>();
+        await foreach (var item in mediator.CreateStream(new TestStreamRequest(3)))
+        {
+            items.Add(item);
+        }
+
+        items.Should().HaveCount(3, "streaming without behaviors should work as before");
+    }
+}
+
+/// <summary>
+/// Stream behavior that tracks execution for testing.
+/// </summary>
+internal sealed class TrackingStreamBehavior<TRequest, TResponse> : IStreamPipelineBehavior<TRequest, TResponse>
+    where TRequest : IStreamRequest<TResponse>
+{
+    public bool WasExecuted { get; private set; }
+
+    public IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        WasExecuted = true;
+        return next();
+    }
+}
+
+/// <summary>
+/// Stream behavior that blocks execution (simulates authorization failure).
+/// </summary>
+internal sealed class BlockingStreamBehavior<TRequest, TResponse> : IStreamPipelineBehavior<TRequest, TResponse>
+    where TRequest : IStreamRequest<TResponse>
+{
+    public IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        throw new UnauthorizedAccessException("Stream access denied");
+    }
 }
 
 public class MediatorConcurrencyTests


### PR DESCRIPTION
## What

Add `IStreamPipelineBehavior<TRequest, TResponse>` interface and wire it into `StreamHandlerWrapper`, enabling pipeline behaviors for streaming requests.

## Why

`CreateStream()` previously bypassed the entire behavior pipeline — no authorization, validation, audit, or any other cross-cutting concern was executed. Streaming endpoints were effectively unprotected.

## Changes

- **`IStreamPipelineBehavior<TRequest, TResponse>`** — new interface for stream-specific pipeline behaviors
- **`StreamHandlerDelegate<TResponse>`** — delegate for the next step in the stream pipeline
- **`StreamHandlerWrapper`** — resolves and chains stream behaviors before yielding
- **`AssemblyScanner`** — now discovers `IStreamPipelineBehavior` implementations
- **3 new unit tests** — behavior execution, blocking (auth simulation), backward compatibility

## Related Issues

Closes #5

## Test Results

- Unit: 135 passed
- Integration: 21 passed
- Load: 18 passed
- **Total: 174 passed, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Added tests for new functionality