### PR TITLE
fix(core): wire pre-processor and post-processor execution into request pipeline

### DIFF
--- a/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
+++ b/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
@@ -37,6 +37,14 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
             throw new HandlerNotFoundException(typeof(TRequest));
         }
 
+        // Resolve pre/post processors
+        var preProcessors = serviceProvider.GetService<IEnumerable<IRequestPreProcessor<TRequest>>>();
+        var postProcessors = serviceProvider.GetService<IEnumerable<IRequestPostProcessor<TRequest, TResponse>>>();
+
+        // Build innermost delegate: pre-processors → handler → post-processors
+        RequestHandlerDelegate<TResponse> handlerDelegate = BuildHandlerDelegate(
+            request, handler, preProcessors, postProcessors, cancellationToken);
+
         // Resolve behaviors — fully typed DI call
         // MS.Extensions.DI returns a cached empty enumerable for unregistered IEnumerable<T>,
         // so this call is fast (~5ns) even when no behaviors exist.
@@ -45,7 +53,7 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
         // Fast path: no behaviors registered
         if (behaviors is null)
         {
-            return handler.Handle(request, cancellationToken);
+            return handlerDelegate();
         }
 
         // Materialize to array — use ICollection fast path when available
@@ -62,7 +70,7 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
             behaviorCount = col.Count;
             if (behaviorCount == 0)
             {
-                return handler.Handle(request, cancellationToken);
+                return handlerDelegate();
             }
             behaviorArray = new IPipelineBehavior<TRequest, TResponse>[behaviorCount];
             col.CopyTo(behaviorArray, 0);
@@ -77,11 +85,11 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
 
         if (behaviorCount == 0)
         {
-            return handler.Handle(request, cancellationToken);
+            return handlerDelegate();
         }
 
         // Build pipeline chain — fully typed, no MethodInfo.Invoke, no object[] boxing
-        RequestHandlerDelegate<TResponse> next = () => handler.Handle(request, cancellationToken);
+        RequestHandlerDelegate<TResponse> next = handlerDelegate;
 
         for (int i = behaviorCount - 1; i >= 0; i--)
         {
@@ -91,6 +99,50 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
         }
 
         return next();
+    }
+
+    private static RequestHandlerDelegate<TResponse> BuildHandlerDelegate(
+        TRequest request,
+        IRequestHandler<TRequest, TResponse> handler,
+        IEnumerable<IRequestPreProcessor<TRequest>>? preProcessors,
+        IEnumerable<IRequestPostProcessor<TRequest, TResponse>>? postProcessors,
+        CancellationToken cancellationToken)
+    {
+        var hasPreProcessors = preProcessors is not null && preProcessors.Any();
+        var hasPostProcessors = postProcessors is not null && postProcessors.Any();
+
+        // Fast path: no processors — direct handler call
+        if (!hasPreProcessors && !hasPostProcessors)
+        {
+            return () => handler.Handle(request, cancellationToken);
+        }
+
+        // Wrap handler with pre/post processor execution
+        return async () =>
+        {
+            // Execute pre-processors
+            if (hasPreProcessors)
+            {
+                foreach (var preProcessor in preProcessors!)
+                {
+                    await preProcessor.Process(request, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            // Execute handler
+            var response = await handler.Handle(request, cancellationToken).ConfigureAwait(false);
+
+            // Execute post-processors
+            if (hasPostProcessors)
+            {
+                foreach (var postProcessor in postProcessors!)
+                {
+                    await postProcessor.Process(request, response, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return response;
+        };
     }
 }
 

--- a/tests/Qorpe.Mediator.UnitTests/Core/MediatorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Core/MediatorTests.cs
@@ -245,6 +245,132 @@ internal sealed class BlockingStreamBehavior<TRequest, TResponse> : IStreamPipel
     }
 }
 
+public class MediatorPrePostProcessorTests
+{
+    [Fact]
+    public async Task Send_WithPreProcessor_ShouldExecuteBeforeHandler()
+    {
+        var executionOrder = new List<string>();
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly));
+        services.AddTransient<IRequestPreProcessor<TestCommand>>(
+            _ => new TrackingPreProcessor<TestCommand>(executionOrder, "pre"));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Send(new TestCommand("test"));
+
+        executionOrder.Should().Contain("pre");
+    }
+
+    [Fact]
+    public async Task Send_WithPostProcessor_ShouldExecuteAfterHandler()
+    {
+        var executionOrder = new List<string>();
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly));
+        services.AddTransient<IRequestPostProcessor<TestCommand, Result>>(
+            _ => new TrackingPostProcessor<TestCommand, Result>(executionOrder, "post"));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Send(new TestCommand("test"));
+
+        executionOrder.Should().Contain("post");
+    }
+
+    [Fact]
+    public async Task Send_WithBothProcessors_ShouldExecuteInCorrectOrder()
+    {
+        var executionOrder = new List<string>();
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly));
+        services.AddTransient<IRequestPreProcessor<TestCommand>>(
+            _ => new TrackingPreProcessor<TestCommand>(executionOrder, "pre"));
+        services.AddTransient<IRequestPostProcessor<TestCommand, Result>>(
+            _ => new TrackingPostProcessor<TestCommand, Result>(executionOrder, "post"));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Send(new TestCommand("test"));
+
+        executionOrder.Should().ContainInOrder("pre", "post");
+    }
+
+    [Fact]
+    public async Task Send_WithMultiplePreProcessors_ShouldExecuteAll()
+    {
+        var executionOrder = new List<string>();
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly));
+        services.AddTransient<IRequestPreProcessor<TestCommand>>(
+            _ => new TrackingPreProcessor<TestCommand>(executionOrder, "pre-1"));
+        services.AddTransient<IRequestPreProcessor<TestCommand>>(
+            _ => new TrackingPreProcessor<TestCommand>(executionOrder, "pre-2"));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Send(new TestCommand("test"));
+
+        executionOrder.Should().ContainInOrder("pre-1", "pre-2");
+    }
+
+    [Fact]
+    public async Task Send_WithoutProcessors_ShouldStillWork()
+    {
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly));
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new TestCommand("test"));
+        result.IsSuccess.Should().BeTrue("backward compatibility must be preserved");
+    }
+}
+
+internal sealed class TrackingPreProcessor<TRequest> : IRequestPreProcessor<TRequest>
+    where TRequest : notnull
+{
+    private readonly List<string> _executionOrder;
+    private readonly string _name;
+
+    public TrackingPreProcessor(List<string> executionOrder, string name)
+    {
+        _executionOrder = executionOrder;
+        _name = name;
+    }
+
+    public ValueTask Process(TRequest request, CancellationToken cancellationToken)
+    {
+        _executionOrder.Add(_name);
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class TrackingPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly List<string> _executionOrder;
+    private readonly string _name;
+
+    public TrackingPostProcessor(List<string> executionOrder, string name)
+    {
+        _executionOrder = executionOrder;
+        _name = name;
+    }
+
+    public ValueTask Process(TRequest request, TResponse response, CancellationToken cancellationToken)
+    {
+        _executionOrder.Add(_name);
+        return ValueTask.CompletedTask;
+    }
+}
+
 public class MediatorConcurrencyTests
 {
     [Fact]


### PR DESCRIPTION
## What

Resolve and invoke `IRequestPreProcessor<TRequest>` and `IRequestPostProcessor<TRequest, TResponse>` within the request pipeline. These interfaces were defined and registered but never called.

## Why

Users implementing pre/post processors found their code registered in DI but silently never invoked — a confusing gap between the API contract and runtime behavior.

## Changes

- **`RequestHandlerWrapper.HandleTyped()`** — resolves pre/post processors and wraps handler call
- Execution order: pre-processors → handler → post-processors (inside behavior pipeline)
- Fast path preserved: zero overhead when no processors are registered
- **5 new unit tests** — pre-processor execution, post-processor execution, correct ordering, multiple processors, backward compatibility

## Related Issues

Closes #7

## Test Results

- Unit: 140 passed
- Integration: 21 passed
- Load: 18 passed
- **Total: 179 passed, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Added tests for new functionality