### PR TITLE
perf(core): replace reflection invocation with compiled delegates in behavior pipeline

### DIFF
--- a/src/Qorpe.Mediator/Implementation/RequestPipeline.cs
+++ b/src/Qorpe.Mediator/Implementation/RequestPipeline.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using Qorpe.Mediator.Abstractions;
 using Qorpe.Mediator.Exceptions;
 
@@ -121,12 +122,23 @@ internal static class RequestPipeline
             var pipelineBehaviorType = typeof(IPipelineBehavior<,>).MakeGenericType(reqType, responseType);
             var handleMethod = pipelineBehaviorType.GetMethod("Handle")!;
 
-            return new Func<object, object, RequestHandlerDelegate<TResponse>, CancellationToken, ValueTask<TResponse>>(
-                (behavior, request, nextDelegate, ct) =>
-                {
-                    var result = handleMethod.Invoke(behavior, new object[] { request, nextDelegate, ct });
-                    return (ValueTask<TResponse>)result!;
-                });
+            // Compile expression tree delegate for zero-reflection invocation:
+            // (object behavior, object request, RequestHandlerDelegate<TResponse> next, CancellationToken ct) =>
+            //     ((IPipelineBehavior<TReq, TResp>)behavior).Handle((TReq)request, next, ct)
+            var behaviorParam = Expression.Parameter(typeof(object), "behavior");
+            var requestParam = Expression.Parameter(typeof(object), "request");
+            var nextParam = Expression.Parameter(typeof(RequestHandlerDelegate<TResponse>), "next");
+            var ctParam = Expression.Parameter(typeof(CancellationToken), "ct");
+
+            var castBehavior = Expression.Convert(behaviorParam, pipelineBehaviorType);
+            var castRequest = Expression.Convert(requestParam, reqType);
+
+            var call = Expression.Call(castBehavior, handleMethod, castRequest, nextParam, ctParam);
+
+            var lambda = Expression.Lambda<Func<object, object, RequestHandlerDelegate<TResponse>, CancellationToken, ValueTask<TResponse>>>(
+                call, behaviorParam, requestParam, nextParam, ctParam);
+
+            return (object)lambda.Compile();
         });
 
         return (Func<object, object, RequestHandlerDelegate<TResponse>, CancellationToken, ValueTask<TResponse>>)invoker;


### PR DESCRIPTION
## What

Replace `MethodInfo.Invoke(behavior, new object[] {...})` with compiled expression tree delegates in `RequestPipeline.GetBehaviorInvoker()`.

## Why

The behavior pipeline cached `MethodInfo` but still used reflection invocation per request, causing boxing and indirect call overhead. The send path already used expression trees — this brings parity.

## Changes

- Compiled expression tree: `(object behavior, object request, next, ct) => ((IPipelineBehavior<T,R>)behavior).Handle((T)request, next, ct)`
- Cached per request type, compiled once
- Zero behavioral change

## Related Issues

Closes #11

## Test Results

- Unit: 140, Integration: 21, Load: 18 — **Total: 179, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings