### PR TITLE
fix(behaviors): distinguish commit-phase failures from handler failures in transaction pipeline

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
@@ -62,31 +62,44 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
 
         await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
+        TResponse response;
+
         try
         {
-            var response = await next().ConfigureAwait(false);
+            response = await next().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Handler failed for {RequestName}, rolling back transaction", requestName);
+            await SafeRollbackAsync(requestName, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
 
+        try
+        {
             await _unitOfWork.CommitAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Committed transaction for {RequestName}", requestName);
-
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Rolling back transaction for {RequestName}", requestName);
-
-            try
-            {
-                await _unitOfWork.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception rollbackEx)
-            {
-                _logger.LogCritical(rollbackEx,
-                    "CRITICAL: Rollback failed for {RequestName}. Original exception preserved.",
-                    requestName);
-            }
-
+            _logger.LogError(ex, "Transaction commit failed for {RequestName}, rolling back", requestName);
+            await SafeRollbackAsync(requestName, cancellationToken).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    private async ValueTask SafeRollbackAsync(string requestName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _unitOfWork!.RollbackAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception rollbackEx)
+        {
+            _logger.LogCritical(rollbackEx,
+                "CRITICAL: Rollback failed for {RequestName}. Original exception preserved.",
+                requestName);
         }
     }
 

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/TransactionBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/TransactionBehaviorTests.cs
@@ -105,4 +105,45 @@ public class TransactionBehaviorTests
         result.IsSuccess.Should().BeTrue();
         await uow.DidNotReceive().BeginTransactionAsync(Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Should_Rollback_On_Commit_Failure_Not_Handler_Failure()
+    {
+        var uow = Substitute.For<IUnitOfWork>();
+        uow.CommitAsync(Arg.Any<CancellationToken>())
+            .Returns(x => throw new InvalidOperationException("commit constraint violation"));
+
+        var behavior = new TransactionBehavior<TransactionalCommand, Result>(_logger, _options, uow);
+        var handlerCalled = false;
+
+        RequestHandlerDelegate<Result> next = () =>
+        {
+            handlerCalled = true;
+            return new ValueTask<Result>(Result.Success());
+        };
+
+        var act = async () => await behavior.Handle(new TransactionalCommand("data"), next, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*commit*");
+        handlerCalled.Should().BeTrue("handler should have succeeded before commit failed");
+        await uow.Received(1).RollbackAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_Preserve_Original_Exception_When_Rollback_Fails_After_Commit_Failure()
+    {
+        var uow = Substitute.For<IUnitOfWork>();
+        uow.CommitAsync(Arg.Any<CancellationToken>())
+            .Returns(x => throw new InvalidOperationException("commit failed"));
+        uow.RollbackAsync(Arg.Any<CancellationToken>())
+            .Returns(x => throw new Exception("rollback also failed"));
+
+        var behavior = new TransactionBehavior<TransactionalCommand, Result>(_logger, _options, uow);
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        var act = async () => await behavior.Handle(new TransactionalCommand("data"), next, CancellationToken.None);
+
+        // Commit exception should be preserved, not the rollback one
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*commit*");
+    }
 }


### PR DESCRIPTION
## What

Separate handler and commit exceptions into distinct catch blocks with specific log messages.

## Why

When `CommitAsync` throws, the log said "Rolling back transaction" with no indication that the handler actually succeeded. Production debugging requires knowing which phase failed.

## Changes

- Split single catch into handler-phase and commit-phase catch blocks
- `SafeRollbackAsync` extracted to eliminate duplication
- **2 new tests**: commit failure with successful handler, exception preservation when rollback also fails

## Related Issues

Closes #15

## Test Results

- Unit: 154, Integration: 21, Load: 18 — **Total: 193, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests for new functionality