### PR TITLE
feat(core): optional polymorphic notification dispatch for type hierarchies

### DIFF
--- a/src/Qorpe.Mediator/DependencyInjection/MediatorOptions.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/MediatorOptions.cs
@@ -50,6 +50,13 @@ public sealed class MediatorOptions
     public TimeSpan ParallelTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Gets or sets whether to enable polymorphic notification dispatch.
+    /// When enabled, publishing a derived notification also invokes handlers
+    /// registered for base notification types. Default is false.
+    /// </summary>
+    public bool EnablePolymorphicNotifications { get; set; }
+
+    /// <summary>
     /// Gets or sets the service lifetime for handlers. Defaults to Transient.
     /// </summary>
     public Microsoft.Extensions.DependencyInjection.ServiceLifetime HandlerLifetime { get; set; } =

--- a/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -56,6 +56,9 @@ public static class ServiceCollectionExtensions
         // Register the notification publisher based on strategy
         RegisterNotificationPublisher(services, options);
 
+        // Register options for injection
+        services.TryAddSingleton(options);
+
         // Register the mediator
         services.TryAddTransient<IMediator, Implementation.Mediator>();
         services.TryAddTransient<ISender>(sp => sp.GetRequiredService<IMediator>());

--- a/src/Qorpe.Mediator/Implementation/Mediator.cs
+++ b/src/Qorpe.Mediator/Implementation/Mediator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.DependencyInjection;
 using Qorpe.Mediator.Exceptions;
 
 namespace Qorpe.Mediator.Implementation;
@@ -13,17 +14,22 @@ public sealed class Mediator : IMediator
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly INotificationPublisher _notificationPublisher;
+    private readonly bool _polymorphicNotifications;
 
     // Cache: requestType -> Func that does typed Send without boxing
     private static readonly ConcurrentDictionary<Type, object> SendDelegateCache = new();
 
+    // Cache: notificationType -> base notification types (for polymorphic dispatch)
+    private static readonly ConcurrentDictionary<Type, Type[]> NotificationTypeHierarchyCache = new();
+
     /// <summary>
     /// Initializes a new instance of <see cref="Mediator"/>.
     /// </summary>
-    public Mediator(IServiceProvider serviceProvider, INotificationPublisher notificationPublisher)
+    public Mediator(IServiceProvider serviceProvider, INotificationPublisher notificationPublisher, MediatorOptions options)
     {
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _notificationPublisher = notificationPublisher ?? throw new ArgumentNullException(nameof(notificationPublisher));
+        _polymorphicNotifications = options?.EnablePolymorphicNotifications ?? false;
     }
 
     /// <inheritdoc />
@@ -102,6 +108,11 @@ public sealed class Mediator : IMediator
         ArgumentNullException.ThrowIfNull(notification);
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (_polymorphicNotifications)
+        {
+            return PublishPolymorphic(notification, typeof(TNotification), cancellationToken);
+        }
+
         var wrapper = HandlerWrapperFactory.GetNotificationWrapper(typeof(TNotification));
         return wrapper.Handle(notification, _serviceProvider, cancellationToken, _notificationPublisher);
     }
@@ -113,8 +124,50 @@ public sealed class Mediator : IMediator
         cancellationToken.ThrowIfCancellationRequested();
 
         var notificationType = notification.GetType();
+
+        if (_polymorphicNotifications)
+        {
+            return PublishPolymorphic(notification, notificationType, cancellationToken);
+        }
+
         var wrapper = HandlerWrapperFactory.GetNotificationWrapper(notificationType);
         return wrapper.Handle(notification, _serviceProvider, cancellationToken, _notificationPublisher);
+    }
+
+    private async ValueTask PublishPolymorphic(INotification notification, Type notificationType, CancellationToken cancellationToken)
+    {
+        var typeHierarchy = NotificationTypeHierarchyCache.GetOrAdd(notificationType, static type =>
+        {
+            var types = new List<Type> { type };
+            var current = type.BaseType;
+
+            while (current is not null && current != typeof(object))
+            {
+                if (typeof(INotification).IsAssignableFrom(current))
+                {
+                    types.Add(current);
+                }
+                current = current.BaseType;
+            }
+
+            // Also check interfaces that implement INotification (excluding INotification itself)
+            foreach (var iface in type.GetInterfaces())
+            {
+                if (iface != typeof(INotification) && typeof(INotification).IsAssignableFrom(iface))
+                {
+                    types.Add(iface);
+                }
+            }
+
+            return types.ToArray();
+        });
+
+        // Publish to each type in the hierarchy
+        for (int i = 0; i < typeHierarchy.Length; i++)
+        {
+            var wrapper = HandlerWrapperFactory.GetNotificationWrapper(typeHierarchy[i]);
+            await wrapper.Handle(notification, _serviceProvider, cancellationToken, _notificationPublisher).ConfigureAwait(false);
+        }
     }
 
     private static Type FindResponseType(Type requestType)

--- a/tests/Qorpe.Mediator.UnitTests/Notifications/PolymorphicNotificationTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Notifications/PolymorphicNotificationTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.DependencyInjection;
+using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.DependencyInjection;
+
+namespace Qorpe.Mediator.UnitTests.Notifications;
+
+public class PolymorphicNotificationTests
+{
+    [Fact]
+    public async Task Should_Invoke_Base_Handler_When_Polymorphic_Enabled()
+    {
+        var baseHandled = new List<string>();
+        var derivedHandled = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(PolymorphicNotificationTests).Assembly);
+            cfg.EnablePolymorphicNotifications = true;
+        });
+        services.AddSingleton<INotificationHandler<BaseOrderEvent>>(
+            new TrackingHandler<BaseOrderEvent>(baseHandled));
+        services.AddSingleton<INotificationHandler<OrderCreatedEvent>>(
+            new TrackingHandler<OrderCreatedEvent>(derivedHandled));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Publish(new OrderCreatedEvent("order-1"));
+
+        derivedHandled.Should().ContainSingle("derived handler should be called");
+        baseHandled.Should().ContainSingle("base handler should also be called with polymorphic dispatch");
+    }
+
+    [Fact]
+    public async Task Should_Not_Invoke_Base_Handler_When_Polymorphic_Disabled()
+    {
+        var baseHandled = new List<string>();
+        var derivedHandled = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(PolymorphicNotificationTests).Assembly);
+            cfg.EnablePolymorphicNotifications = false; // default
+        });
+        services.AddSingleton<INotificationHandler<BaseOrderEvent>>(
+            new TrackingHandler<BaseOrderEvent>(baseHandled));
+        services.AddSingleton<INotificationHandler<OrderCreatedEvent>>(
+            new TrackingHandler<OrderCreatedEvent>(derivedHandled));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Publish(new OrderCreatedEvent("order-1"));
+
+        derivedHandled.Should().ContainSingle("derived handler should be called");
+        baseHandled.Should().BeEmpty("base handler should NOT be called without polymorphic dispatch");
+    }
+
+    [Fact]
+    public async Task Should_Handle_Three_Level_Hierarchy()
+    {
+        var baseHandled = new List<string>();
+        var midHandled = new List<string>();
+        var leafHandled = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(PolymorphicNotificationTests).Assembly);
+            cfg.EnablePolymorphicNotifications = true;
+        });
+        services.AddSingleton<INotificationHandler<BaseOrderEvent>>(
+            new TrackingHandler<BaseOrderEvent>(baseHandled));
+        services.AddSingleton<INotificationHandler<OrderCreatedEvent>>(
+            new TrackingHandler<OrderCreatedEvent>(midHandled));
+        services.AddSingleton<INotificationHandler<PriorityOrderCreatedEvent>>(
+            new TrackingHandler<PriorityOrderCreatedEvent>(leafHandled));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Publish(new PriorityOrderCreatedEvent("order-1", "high"));
+
+        leafHandled.Should().ContainSingle();
+        midHandled.Should().ContainSingle();
+        baseHandled.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Should_Not_Duplicate_When_Publishing_Base_Type_Directly()
+    {
+        var baseHandled = new List<string>();
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(PolymorphicNotificationTests).Assembly);
+            cfg.EnablePolymorphicNotifications = true;
+        });
+        services.AddSingleton<INotificationHandler<BaseOrderEvent>>(
+            new TrackingHandler<BaseOrderEvent>(baseHandled));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        await mediator.Publish(new BaseOrderEvent("order-1"));
+
+        baseHandled.Should().ContainSingle("base handler should only be called once");
+    }
+}
+
+// Test notification hierarchy
+public record BaseOrderEvent(string OrderId) : INotification;
+public record OrderCreatedEvent(string OrderId) : BaseOrderEvent(OrderId);
+public record PriorityOrderCreatedEvent(string OrderId, string Priority) : OrderCreatedEvent(OrderId);
+
+internal sealed class TrackingHandler<T> : INotificationHandler<T> where T : INotification
+{
+    private readonly List<string> _tracked;
+
+    public TrackingHandler(List<string> tracked) => _tracked = tracked;
+
+    public ValueTask Handle(T notification, CancellationToken cancellationToken)
+    {
+        _tracked.Add(typeof(T).Name);
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## What

Add opt-in `MediatorOptions.EnablePolymorphicNotifications` that walks the type hierarchy when publishing notifications, invoking handlers registered for base types.

## Why

Publishing `DerivedEvent` only called handlers for that exact type. Handlers for `BaseEvent` were never invoked, breaking common domain event patterns where a base handler should react to all derived events.

## Changes

- **`MediatorOptions.EnablePolymorphicNotifications`** — opt-in, default false
- **`Mediator.PublishPolymorphic`** — walks base classes + interfaces implementing INotification
- **`NotificationTypeHierarchyCache`** — cached per notification type
- **`MediatorOptions`** registered as singleton for injection
- **4 new tests** — enabled/disabled modes, 3-level hierarchy, no duplication

## Related Issues

Closes #21

## Test Results

- Unit: 163, Integration: 21, Load: 18 — **Total: 202, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests for new functionality
- [x] Backward compatible (opt-in, default off)