### PR TITLE
feat(core): startup validation for handler registration completeness

### DIFF
--- a/src/Qorpe.Mediator/DependencyInjection/MediatorOptions.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/MediatorOptions.cs
@@ -57,6 +57,13 @@ public sealed class MediatorOptions
     public bool EnablePolymorphicNotifications { get; set; }
 
     /// <summary>
+    /// Gets or sets whether to validate handler registrations at startup.
+    /// When enabled, verifies that every discovered request type has a corresponding handler.
+    /// Throws an exception listing all missing handlers if any are found. Default is false.
+    /// </summary>
+    public bool ValidateOnStartup { get; set; }
+
+    /// <summary>
     /// Gets or sets the service lifetime for handlers. Defaults to Transient.
     /// </summary>
     public Microsoft.Extensions.DependencyInjection.ServiceLifetime HandlerLifetime { get; set; } =

--- a/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -75,6 +75,11 @@ public static class ServiceCollectionExtensions
                 var descriptor = new ServiceDescriptor(reg.ServiceType, reg.ImplementationType, options.HandlerLifetime);
                 services.TryAdd(descriptor);
             }
+
+            if (options.ValidateOnStartup)
+            {
+                ValidateHandlerRegistrations(options.AssembliesToRegister, registrations);
+            }
         }
 
         return services;
@@ -101,6 +106,85 @@ public static class ServiceCollectionExtensions
             default:
                 services.TryAddSingleton<INotificationPublisher>(new ForeachNotificationPublisher(stopOnFirstError: true));
                 break;
+        }
+    }
+
+    private static void ValidateHandlerRegistrations(
+        List<System.Reflection.Assembly> assemblies,
+        IReadOnlyList<HandlerRegistration> registrations)
+    {
+        // Build set of registered handler service types
+        var registeredHandlerTypes = new HashSet<Type>();
+        for (int i = 0; i < registrations.Count; i++)
+        {
+            var reg = registrations[i];
+            if (reg.ServiceType.IsGenericType)
+            {
+                var genericDef = reg.ServiceType.GetGenericTypeDefinition();
+                if (genericDef == typeof(IRequestHandler<,>) || genericDef == typeof(IStreamRequestHandler<,>))
+                {
+                    registeredHandlerTypes.Add(reg.ServiceType);
+                }
+            }
+        }
+
+        // Scan for all request types and verify handlers exist
+        var missingHandlers = new List<Type>();
+
+        for (int i = 0; i < assemblies.Count; i++)
+        {
+            Type[] types;
+            try
+            {
+                types = assemblies[i].GetTypes();
+            }
+            catch (System.Reflection.ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            for (int j = 0; j < types.Length; j++)
+            {
+                var type = types[j];
+                if (type.IsAbstract || type.IsInterface || type.IsGenericTypeDefinition)
+                    continue;
+
+                var interfaces = type.GetInterfaces();
+                for (int k = 0; k < interfaces.Length; k++)
+                {
+                    var iface = interfaces[k];
+                    if (!iface.IsGenericType) continue;
+
+                    var genericDef = iface.GetGenericTypeDefinition();
+
+                    if (genericDef == typeof(IRequest<>))
+                    {
+                        var responseType = iface.GetGenericArguments()[0];
+                        var handlerType = typeof(IRequestHandler<,>).MakeGenericType(type, responseType);
+                        if (!registeredHandlerTypes.Contains(handlerType))
+                        {
+                            missingHandlers.Add(type);
+                        }
+                    }
+                    else if (genericDef == typeof(IStreamRequest<>))
+                    {
+                        var responseType = iface.GetGenericArguments()[0];
+                        var handlerType = typeof(IStreamRequestHandler<,>).MakeGenericType(type, responseType);
+                        if (!registeredHandlerTypes.Contains(handlerType))
+                        {
+                            missingHandlers.Add(type);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (missingHandlers.Count > 0)
+        {
+            var typeNames = string.Join(", ", missingHandlers.Select(t => t.Name));
+            throw new InvalidOperationException(
+                $"Handler registration validation failed. {missingHandlers.Count} request type(s) have no registered handler: {typeNames}. " +
+                $"Create handler implementations or disable validation with ValidateOnStartup = false.");
         }
     }
 }

--- a/tests/Qorpe.Mediator.UnitTests/Core/AssemblyScannerTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Core/AssemblyScannerTests.cs
@@ -48,3 +48,66 @@ public class AssemblyScannerDuplicateDetectionTests
 // Note: No duplicate handler types defined here — they would break all tests
 // that scan the unit test assembly. Duplicate detection is tested via the
 // load test assembly (multiple notification handlers) and exception validation.
+
+public class StartupValidationTests
+{
+    [Fact]
+    public void Should_Not_Throw_When_Validation_Disabled_Even_With_Missing_Handlers()
+    {
+        var services = new ServiceCollection();
+
+        // OrphanCommand has no handler, but validation is disabled (default)
+        var act = () => services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(TestCommand).Assembly);
+            cfg.ValidateOnStartup = false;
+        });
+
+        act.Should().NotThrow("validation is disabled by default");
+    }
+
+    [Fact]
+    public void Should_Throw_When_Handler_Missing_And_Validation_Enabled()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddQorpeMediator(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(OrphanCommand).Assembly);
+            cfg.ValidateOnStartup = true;
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*OrphanCommand*")
+            .WithMessage("*no registered handler*");
+    }
+
+    [Fact]
+    public void Should_List_All_Missing_Handlers_In_Error_Message()
+    {
+        var services = new ServiceCollection();
+
+        try
+        {
+            services.AddQorpeMediator(cfg =>
+            {
+                cfg.RegisterServicesFromAssembly(typeof(OrphanCommand).Assembly);
+                cfg.ValidateOnStartup = true;
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Should mention OrphanCommand and AnotherOrphanQuery
+            ex.Message.Should().Contain("OrphanCommand");
+            ex.Message.Should().Contain("AnotherOrphanQuery");
+            return;
+        }
+
+        Assert.Fail("Should have thrown InvalidOperationException");
+    }
+}
+
+// Request types with no handler — used to test startup validation
+public sealed record OrphanCommand(string Data) : ICommand<Result>;
+public sealed record AnotherOrphanQuery(int Id) : IQuery<Result<string>>;
+// Intentionally no handlers for these types


### PR DESCRIPTION
## What

Add opt-in `MediatorOptions.ValidateOnStartup` that verifies every discovered request type has a handler at registration time.

## Why

Missing handlers were only discovered at runtime when `Send()` was called — potentially months after deployment. This shifts detection to startup.

## Changes

- **`MediatorOptions.ValidateOnStartup`** — opt-in, default false
- **`ValidateHandlerRegistrations`** — scans for `IRequest<>` and `IStreamRequest<>` types, checks against registered handlers
- Error message lists ALL missing types for batch debugging
- **3 new tests** — disabled mode, single missing handler, multiple missing handlers

## Related Issues

Closes #27

## Test Results

- Unit: 168, Integration: 21, Load: 18 — **Total: 207, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests for new functionality
- [x] Backward compatible (opt-in, default off)