### PR TITLE
fix(core): preserve handler exceptions when parallel notification publishing times out

### DIFF
--- a/src/Qorpe.Mediator/Implementation/ParallelNotificationPublisher.cs
+++ b/src/Qorpe.Mediator/Implementation/ParallelNotificationPublisher.cs
@@ -43,7 +43,15 @@ public sealed class ParallelNotificationPublisher : INotificationPublisher
         var tasks = new Task[handlerExecutors.Count];
         for (int i = 0; i < handlerExecutors.Count; i++)
         {
-            tasks[i] = handlerExecutors[i].HandlerCallback(notification, cancellationToken).AsTask();
+            try
+            {
+                tasks[i] = handlerExecutors[i].HandlerCallback(notification, cancellationToken).AsTask();
+            }
+            catch (Exception ex)
+            {
+                // Handler threw synchronously — wrap in faulted task
+                tasks[i] = Task.FromException(ex);
+            }
         }
 
         if (_timeout.HasValue)
@@ -57,13 +65,67 @@ public sealed class ParallelNotificationPublisher : INotificationPublisher
             }
             catch (OperationCanceledException) when (cts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
-                throw new TimeoutException(
-                    $"Notification handlers did not complete within the timeout of {_timeout.Value.TotalMilliseconds}ms.");
+                // Timeout occurred — collect exceptions from handlers that failed before the timeout
+                CollectAndThrowWithTimeout(tasks, _timeout.Value);
+            }
+            catch (Exception) when (HasPendingTasks(tasks))
+            {
+                // Some handlers failed but others are still running — wait for timeout then report all
+                try
+                {
+                    await Task.WhenAll(tasks).WaitAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    CollectAndThrowWithTimeout(tasks, _timeout.Value);
+                }
+                catch
+                {
+                    // All tasks completed (with failures) — let the normal WhenAll path handle it
+                }
+
+                // Re-run WhenAll to propagate all exceptions via AggregateException
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
         }
         else
         {
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+    }
+
+    private static bool HasPendingTasks(Task[] tasks)
+    {
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            if (!tasks[i].IsCompleted)
+                return true;
+        }
+        return false;
+    }
+
+    private static void CollectAndThrowWithTimeout(Task[] tasks, TimeSpan timeout)
+    {
+        var handlerExceptions = new List<Exception>();
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            if (tasks[i].IsFaulted && tasks[i].Exception is { } taskEx)
+            {
+                handlerExceptions.AddRange(taskEx.InnerExceptions);
+            }
+        }
+
+        var timeoutException = new TimeoutException(
+            $"Notification handlers did not complete within the timeout of {timeout.TotalMilliseconds}ms. " +
+            $"{handlerExceptions.Count} handler(s) also failed with exceptions.");
+
+        if (handlerExceptions.Count > 0)
+        {
+            throw new AggregateException(
+                timeoutException.Message,
+                new Exception[] { timeoutException }.Concat(handlerExceptions));
+        }
+
+        throw timeoutException;
     }
 }

--- a/tests/Qorpe.Mediator.UnitTests/Notifications/NotificationPublisherTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Notifications/NotificationPublisherTests.cs
@@ -118,4 +118,44 @@ public class ParallelNotificationPublisherTests
 
         await act.Should().ThrowAsync<TimeoutException>();
     }
+
+    [Fact]
+    public async Task Publish_WithTimeout_ShouldPreserveHandlerExceptions()
+    {
+        var publisher = new ParallelNotificationPublisher(TimeSpan.FromMilliseconds(100));
+
+        var executors = new[]
+        {
+            // Handler that fails immediately
+            CreateExecutor((_, _) => throw new InvalidOperationException("handler failed")),
+            // Handler that runs forever (causes timeout)
+            CreateExecutor(async (_, ct) => await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None))
+        };
+
+        var act = async () => await publisher.Publish(executors,
+            Substitute.For<INotification>(), CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<AggregateException>();
+        ex.Which.InnerExceptions.Should().Contain(e => e is TimeoutException);
+        ex.Which.InnerExceptions.Should().Contain(e => e is InvalidOperationException && e.Message == "handler failed");
+    }
+
+    [Fact]
+    public async Task Publish_WithTimeout_NoHandlerFailures_ShouldThrowPlainTimeout()
+    {
+        var publisher = new ParallelNotificationPublisher(TimeSpan.FromMilliseconds(50));
+
+        // Use 2 handlers to bypass single-handler optimization
+        var executors = new[]
+        {
+            CreateExecutor(async (_, ct) => await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None)),
+            CreateExecutor(async (_, ct) => await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None))
+        };
+
+        var act = async () => await publisher.Publish(executors,
+            Substitute.For<INotification>(), CancellationToken.None);
+
+        // No handler failures — should be plain TimeoutException, not AggregateException
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
 }


### PR DESCRIPTION
## What

Collect and include handler exceptions that occurred before timeout in the thrown exception. Also handle synchronous handler throws gracefully.

## Why

Previously, when timeout occurred, any handler exceptions were silently lost — only `TimeoutException` was thrown. Root cause information was discarded.

## Changes

- **`CollectAndThrowWithTimeout`** — gathers faulted task exceptions, throws `AggregateException` with both timeout and handler exceptions
- **Synchronous throw handling** — wraps synchronous handler exceptions in `Task.FromException`
- **Mixed failure handling** — when some handlers fail and others are pending, waits for timeout then reports all
- **2 new tests** — exception preservation with timeout, plain timeout without failures

## Related Issues

Closes #29

## Test Results

- Unit: 170, Integration: 21, Load: 18 — **Total: 209, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests