### PR TITLE
feat(behaviors): structured success logging with attempt count in retry pipeline

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
@@ -71,7 +71,16 @@ public sealed class RetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
         {
             try
             {
-                return await next().ConfigureAwait(false);
+                var response = await next().ConfigureAwait(false);
+
+                if (attempt > 0)
+                {
+                    _logger.LogInformation(
+                        "Request {RequestName} succeeded on attempt {Attempt}/{MaxRetries}",
+                        typeof(TRequest).Name, attempt + 1, maxRetries);
+                }
+
+                return response;
             }
             catch (Exception ex) when (ShouldRetry(ex, attempt, maxRetries, cancellationToken))
             {

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/RetryBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/RetryBehaviorTests.cs
@@ -151,4 +151,52 @@ public class RetryBehaviorTests
         var result = await behavior.Handle(new RetryableCommand("data"), next, CancellationToken.None);
         result.IsSuccess.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task Should_Log_Success_Attempt_After_Retry()
+    {
+        var behavior = new RetryBehavior<RetryableCommand, Result>(_logger, _options);
+        var callCount = 0;
+
+        RequestHandlerDelegate<Result> next = () =>
+        {
+            callCount++;
+            if (callCount < 2)
+                throw new TimeoutException("transient");
+            return new ValueTask<Result>(Result.Success());
+        };
+
+        var result = await behavior.Handle(new RetryableCommand("data"), next, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        callCount.Should().Be(2, "should succeed on second attempt");
+
+        // Verify the success log was emitted (attempt 2/3)
+        _logger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("succeeded on attempt")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Should_Not_Log_Success_Attempt_On_First_Try()
+    {
+        var behavior = new RetryBehavior<RetryableCommand, Result>(_logger, _options);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        var result = await behavior.Handle(new RetryableCommand("data"), next, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        // Should NOT log success attempt when first try succeeds
+        _logger.DidNotReceive().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("succeeded on attempt")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
 }


### PR DESCRIPTION
## What

Log an informational message when a request succeeds after retry, including attempt number.

## Why

Operators couldn't tell how many retries were needed for successful requests — only failures were logged. This is essential for monitoring flaky dependency patterns.

## Changes

- Success log: `"Request {Name} succeeded on attempt {N}/{Max}"`
- Zero overhead on first-attempt success (no log emitted)
- **2 new tests** — success log after retry, no log on first success

## Related Issues

Closes #31

## Test Results

- Unit: 172, Integration: 21, Load: 18 — **Total: 211, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests