### PR TITLE
feat(behaviors): programmatic cache invalidation for command-query consistency

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Attributes/InvalidatesCacheAttribute.cs
+++ b/src/Qorpe.Mediator.Behaviors/Attributes/InvalidatesCacheAttribute.cs
@@ -1,0 +1,23 @@
+namespace Qorpe.Mediator.Behaviors.Attributes;
+
+/// <summary>
+/// Marks a command as invalidating cached entries with the specified key prefix
+/// after successful execution.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class InvalidatesCacheAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the cache key prefix to invalidate.
+    /// </summary>
+    public string KeyPrefix { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InvalidatesCacheAttribute"/>.
+    /// </summary>
+    /// <param name="keyPrefix">The cache key prefix to invalidate after successful execution.</param>
+    public InvalidatesCacheAttribute(string keyPrefix)
+    {
+        KeyPrefix = keyPrefix ?? throw new ArgumentNullException(nameof(keyPrefix));
+    }
+}

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/CacheInvalidationBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/CacheInvalidationBehavior.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.Behaviors.Attributes;
+
+namespace Qorpe.Mediator.Behaviors.Behaviors;
+
+/// <summary>
+/// Pipeline behavior that invalidates cache entries after successful command execution.
+/// Triggered by [InvalidatesCache("prefix")] attribute on command types.
+/// Executes after the handler succeeds — never invalidates on failure.
+/// </summary>
+public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>, IBehaviorOrder
+    where TRequest : IRequest<TResponse>
+{
+    public int Order => 1001; // Just after CachingBehavior (1000)
+    private readonly ICacheInvalidator? _cacheInvalidator;
+    private readonly ILogger<CacheInvalidationBehavior<TRequest, TResponse>> _logger;
+
+    public CacheInvalidationBehavior(
+        ILogger<CacheInvalidationBehavior<TRequest, TResponse>> logger,
+        ICacheInvalidator? cacheInvalidator = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _cacheInvalidator = cacheInvalidator;
+    }
+
+    public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var invalidateAttrs = typeof(TRequest).GetCustomAttributes(typeof(InvalidatesCacheAttribute), true)
+            as InvalidatesCacheAttribute[];
+
+        if (invalidateAttrs is null || invalidateAttrs.Length == 0 || _cacheInvalidator is null)
+        {
+            return await next().ConfigureAwait(false);
+        }
+
+        // Execute the handler first
+        var response = await next().ConfigureAwait(false);
+
+        // Invalidate cache entries after successful execution
+        for (int i = 0; i < invalidateAttrs.Length; i++)
+        {
+            try
+            {
+                await _cacheInvalidator.InvalidateAsync(invalidateAttrs[i].KeyPrefix, cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug("Invalidated cache entries with prefix '{Prefix}' after {RequestName}",
+                    invalidateAttrs[i].KeyPrefix, typeof(TRequest).Name);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Cache invalidation failed for prefix '{Prefix}' after {RequestName}",
+                    invalidateAttrs[i].KeyPrefix, typeof(TRequest).Name);
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/Qorpe.Mediator.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
+++ b/src/Qorpe.Mediator.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
@@ -142,11 +142,12 @@ public static class BehaviorServiceCollectionExtensions
         else services.Configure<CachingBehaviorOptions>(_ => { });
 
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CacheInvalidationBehavior<,>));
         return services;
     }
 
     /// <summary>
-    /// Adds all 9 behaviors in recommended pipeline order.
+    /// Adds all behaviors in recommended pipeline order.
     /// </summary>
     public static IServiceCollection AddQorpeAllBehaviors(
         this IServiceCollection services,

--- a/src/Qorpe.Mediator/Abstractions/ICacheInvalidator.cs
+++ b/src/Qorpe.Mediator/Abstractions/ICacheInvalidator.cs
@@ -1,0 +1,21 @@
+namespace Qorpe.Mediator.Abstractions;
+
+/// <summary>
+/// Provides programmatic cache invalidation for cached query results.
+/// Use after commands that modify data to ensure query cache consistency.
+/// </summary>
+public interface ICacheInvalidator
+{
+    /// <summary>
+    /// Invalidates all cache entries whose keys start with the given prefix.
+    /// </summary>
+    /// <param name="keyPrefix">The cache key prefix to match.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask InvalidateAsync(string keyPrefix, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invalidates all cached entries.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask InvalidateAllAsync(CancellationToken cancellationToken = default);
+}

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/CacheInvalidationBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/CacheInvalidationBehaviorTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Logging;
+using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.Behaviors.Attributes;
+using Qorpe.Mediator.Behaviors.Behaviors;
+using Qorpe.Mediator.Results;
+
+namespace Qorpe.Mediator.UnitTests.Behaviors;
+
+public class CacheInvalidationBehaviorTests
+{
+    private readonly ILogger<CacheInvalidationBehavior<InvalidatingCommand, Result>> _logger =
+        Substitute.For<ILogger<CacheInvalidationBehavior<InvalidatingCommand, Result>>>();
+
+    [Fact]
+    public async Task Should_Invalidate_Cache_After_Successful_Execution()
+    {
+        var invalidator = Substitute.For<ICacheInvalidator>();
+        var behavior = new CacheInvalidationBehavior<InvalidatingCommand, Result>(_logger, invalidator);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new InvalidatingCommand("data"), next, CancellationToken.None);
+
+        await invalidator.Received(1).InvalidateAsync("OrderCache", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_Not_Invalidate_On_Handler_Failure()
+    {
+        var invalidator = Substitute.For<ICacheInvalidator>();
+        var behavior = new CacheInvalidationBehavior<InvalidatingCommand, Result>(_logger, invalidator);
+
+        RequestHandlerDelegate<Result> next = () => throw new InvalidOperationException("fail");
+
+        var act = async () => await behavior.Handle(new InvalidatingCommand("data"), next, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await invalidator.DidNotReceive().InvalidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_Skip_When_No_Attribute()
+    {
+        var cmdLogger = Substitute.For<ILogger<CacheInvalidationBehavior<Helpers.TestCommand, Result>>>();
+        var invalidator = Substitute.For<ICacheInvalidator>();
+        var behavior = new CacheInvalidationBehavior<Helpers.TestCommand, Result>(cmdLogger, invalidator);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new Helpers.TestCommand("data"), next, CancellationToken.None);
+
+        await invalidator.DidNotReceive().InvalidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_Skip_When_No_Invalidator_Registered()
+    {
+        var behavior = new CacheInvalidationBehavior<InvalidatingCommand, Result>(_logger, cacheInvalidator: null);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        var result = await behavior.Handle(new InvalidatingCommand("data"), next, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Should_Handle_Multiple_InvalidatesCache_Attributes()
+    {
+        var invalidator = Substitute.For<ICacheInvalidator>();
+        var multiLogger = Substitute.For<ILogger<CacheInvalidationBehavior<MultiInvalidatingCommand, Result>>>();
+        var behavior = new CacheInvalidationBehavior<MultiInvalidatingCommand, Result>(multiLogger, invalidator);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new MultiInvalidatingCommand("data"), next, CancellationToken.None);
+
+        await invalidator.Received(1).InvalidateAsync("OrderCache", Arg.Any<CancellationToken>());
+        await invalidator.Received(1).InvalidateAsync("UserCache", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_Continue_On_Invalidation_Failure()
+    {
+        var invalidator = Substitute.For<ICacheInvalidator>();
+        invalidator.InvalidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(x => throw new Exception("cache down"));
+
+        var behavior = new CacheInvalidationBehavior<InvalidatingCommand, Result>(_logger, invalidator);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        // Should not throw — cache invalidation failure is non-fatal
+        var result = await behavior.Handle(new InvalidatingCommand("data"), next, CancellationToken.None);
+        result.IsSuccess.Should().BeTrue();
+    }
+}
+
+[InvalidatesCache("OrderCache")]
+public sealed record InvalidatingCommand(string Data) : ICommand<Result>;
+
+public sealed class InvalidatingCommandHandler : ICommandHandler<InvalidatingCommand>
+{
+    public ValueTask<Result> Handle(InvalidatingCommand request, CancellationToken cancellationToken)
+        => new(Result.Success());
+}
+
+[InvalidatesCache("OrderCache")]
+[InvalidatesCache("UserCache")]
+public sealed record MultiInvalidatingCommand(string Data) : ICommand<Result>;
+
+public sealed class MultiInvalidatingCommandHandler : ICommandHandler<MultiInvalidatingCommand>
+{
+    public ValueTask<Result> Handle(MultiInvalidatingCommand request, CancellationToken cancellationToken)
+        => new(Result.Success());
+}


### PR DESCRIPTION
## What

Add `ICacheInvalidator` interface, `[InvalidatesCache]` attribute, and `CacheInvalidationBehavior` for automatic cache invalidation after successful command execution.

## Why

Cached query results persisted until TTL expiry even after data-modifying commands. No programmatic invalidation mechanism existed.

## Changes

- **`ICacheInvalidator`** — interface with `InvalidateAsync(prefix)` and `InvalidateAllAsync()`
- **`[InvalidatesCache("prefix")]`** — `AllowMultiple` attribute for commands
- **`CacheInvalidationBehavior`** — executes after handler success, non-fatal on failure
- Auto-registered with `AddQorpeCaching()`
- **6 new tests** — invalidation, handler failure, no-op, multi-prefix, failure tolerance

## Related Issues

Closes #33

## Test Results

- Unit: 178, Integration: 21, Load: 18 — **Total: 217, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests