### PR TITLE
feat(behaviors): configurable performance monitoring thresholds per request type

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Attributes/PerformanceThresholdAttribute.cs
+++ b/src/Qorpe.Mediator.Behaviors/Attributes/PerformanceThresholdAttribute.cs
@@ -1,0 +1,20 @@
+namespace Qorpe.Mediator.Behaviors.Attributes;
+
+/// <summary>
+/// Overrides global performance monitoring thresholds for a specific request type.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class PerformanceThresholdAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets the warning threshold in milliseconds.
+    /// Requests exceeding this duration are logged at Warning level.
+    /// </summary>
+    public int WarningMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the critical threshold in milliseconds.
+    /// Requests exceeding this duration are logged at Error level.
+    /// </summary>
+    public int CriticalMs { get; set; }
+}

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/PerformanceBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/PerformanceBehavior.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.Behaviors.Attributes;
 using Qorpe.Mediator.Behaviors.Configuration;
 
 namespace Qorpe.Mediator.Behaviors.Behaviors;
@@ -52,24 +53,34 @@ public sealed class PerformanceBehavior<TRequest, TResponse> : IPipelineBehavior
 
         var requestName = typeof(TRequest).Name;
 
-        // Over 30 seconds — critical
+        // Check per-request attribute override, fall back to global options
+        var thresholdAttr = typeof(TRequest).GetCustomAttributes(typeof(PerformanceThresholdAttribute), true)
+            as PerformanceThresholdAttribute[];
+        var warningMs = thresholdAttr is { Length: > 0 } && thresholdAttr[0].WarningMs > 0
+            ? thresholdAttr[0].WarningMs
+            : _options.WarningThresholdMs;
+        var criticalMs = thresholdAttr is { Length: > 0 } && thresholdAttr[0].CriticalMs > 0
+            ? thresholdAttr[0].CriticalMs
+            : _options.CriticalThresholdMs;
+
+        // Over 30 seconds — always critical regardless of thresholds
         if (elapsedMs > 30_000)
         {
             _logger.LogCritical(
                 "CRITICAL: {RequestName} took {ElapsedMs}ms (over 30s threshold)",
                 requestName, elapsedMs);
         }
-        else if (elapsedMs > _options.CriticalThresholdMs)
+        else if (elapsedMs > criticalMs)
         {
             _logger.LogError(
                 "SLOW: {RequestName} took {ElapsedMs}ms (critical threshold: {Threshold}ms)",
-                requestName, elapsedMs, _options.CriticalThresholdMs);
+                requestName, elapsedMs, criticalMs);
         }
-        else if (elapsedMs > _options.WarningThresholdMs)
+        else if (elapsedMs > warningMs)
         {
             _logger.LogWarning(
                 "SLOW: {RequestName} took {ElapsedMs}ms (warning threshold: {Threshold}ms)",
-                requestName, elapsedMs, _options.WarningThresholdMs);
+                requestName, elapsedMs, warningMs);
         }
 
         return response;

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/PerformanceBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/PerformanceBehaviorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.Behaviors.Attributes;
 using Qorpe.Mediator.Behaviors.Behaviors;
 using Qorpe.Mediator.Behaviors.Configuration;
 using Qorpe.Mediator.Results;
@@ -62,4 +63,60 @@ public class PerformanceBehaviorTests
         result.IsSuccess.Should().BeTrue();
         // Logger will have been called with Warning level
     }
+
+    [Fact]
+    public async Task Should_Use_Attribute_Thresholds_Over_Global_Options()
+    {
+        var logger = Substitute.For<ILogger<PerformanceBehavior<CustomThresholdCommand, Result>>>();
+        // Global: 500ms warning — but attribute says 1ms warning
+        var opts = Options.Create(new PerformanceBehaviorOptions { WarningThresholdMs = 500, CriticalThresholdMs = 5000 });
+        var behavior = new PerformanceBehavior<CustomThresholdCommand, Result>(logger, opts);
+
+        RequestHandlerDelegate<Result> next = async () =>
+        {
+            await Task.Delay(10); // 10ms — above attribute warning (1ms) but below global (500ms)
+            return Result.Success();
+        };
+
+        var result = await behavior.Handle(new CustomThresholdCommand("test"), next, CancellationToken.None);
+        result.IsSuccess.Should().BeTrue();
+
+        // Should have logged at Warning level using attribute threshold (1ms), not global (500ms)
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("SLOW")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Should_Fall_Back_To_Global_When_No_Attribute()
+    {
+        var logger = Substitute.For<ILogger<PerformanceBehavior<TestCommand, Result>>>();
+        var opts = Options.Create(new PerformanceBehaviorOptions { WarningThresholdMs = 500 });
+        var behavior = new PerformanceBehavior<TestCommand, Result>(logger, opts);
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        var result = await behavior.Handle(new TestCommand("test"), next, CancellationToken.None);
+        result.IsSuccess.Should().BeTrue();
+
+        // Fast execution — should NOT warn (global threshold is 500ms)
+        logger.DidNotReceive().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("SLOW")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}
+
+[PerformanceThreshold(WarningMs = 1, CriticalMs = 100)]
+public sealed record CustomThresholdCommand(string Data) : ICommand<Result>;
+
+public sealed class CustomThresholdCommandHandler : ICommandHandler<CustomThresholdCommand>
+{
+    public ValueTask<Result> Handle(CustomThresholdCommand request, CancellationToken cancellationToken)
+        => new(Result.Success());
 }


### PR DESCRIPTION
## What

Add `[PerformanceThreshold(WarningMs, CriticalMs)]` attribute for per-request threshold overrides.

## Why

Global thresholds don't fit all request types — batch jobs and health checks have very different acceptable latencies.

## Changes

- **`[PerformanceThreshold]`** attribute with `WarningMs` and `CriticalMs`
- Attribute takes precedence over global `PerformanceBehaviorOptions`
- 30s hard ceiling always applies
- **2 new tests** — attribute override, global fallback

## Related Issues

Closes #35

## Test Results

- Unit: 180, Integration: 21, Load: 18 — **Total: 219, 0 failures, 0 warnings**

## Checklist

- [x] All tests pass
- [x] No new warnings
- [x] Added tests