### PR TITLE
docs: update benchmark values with optimized send path results

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,17 @@ Benchmarked against MediatR v12 using BenchmarkDotNet. Full results: [docs/BENCH
 
 | Handlers | Qorpe | MediatR v12 | Result |
 |----------|-------|-------------|--------|
-| 1 handler | 27 ns / 88 B | 50 ns / 288 B | **47% faster, 3.3x less memory** |
-| 10 handlers | 75 ns / 376 B | 205 ns / 1,656 B | **63% faster, 4.4x less memory** |
-| 100 handlers | 578 ns / 3,256 B | 1,722 ns / 15,336 B | **66% faster, 4.7x less memory** |
+| 1 handler | 24 ns / 88 B | 46 ns / 288 B | **48% faster, 3.3x less memory** |
+| 10 handlers | 69 ns / 376 B | 187 ns / 1,656 B | **63% faster, 4.4x less memory** |
+| 100 handlers | 532 ns / 3,256 B | 1,552 ns / 15,336 B | **66% faster, 4.7x less memory** |
 
-### Send (Pipeline) — MediatR has lower latency, Qorpe has more features
+### Send (Pipeline) — Equal speed, Qorpe uses less memory
 
-| Behaviors | Qorpe | MediatR v12 | Notes |
-|-----------|-------|-------------|-------|
-| 1 behavior | 83 ns / 352 B | 62 ns / 368 B | Qorpe includes pre/post processors, behavior ordering |
-| 5 behaviors | 135 ns / 896 B | 123 ns / 944 B | Qorpe uses less memory |
-
-> Send overhead comes from features MediatR lacks: `IRequestPreProcessor`, `IRequestPostProcessor`, `IBehaviorOrder`, cancellation diagnostics. The ~30 ns difference is negligible vs typical handler execution (1-100+ ms).
+| Behaviors | Qorpe | MediatR v12 | Result |
+|-----------|-------|-------------|--------|
+| 1 behavior | 61 ns / 288 B | 59 ns / 368 B | ~equal speed, **22% less memory** |
+| 3 behaviors | 89 ns / 560 B | 90 ns / 656 B | **Qorpe 1% faster, 15% less memory** |
+| 5 behaviors | 119 ns / 832 B | 118 ns / 944 B | ~equal speed, **12% less memory** |
 
 - - -
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -11,7 +11,7 @@
 | **OS** | macOS (Apple M5) |
 | **BenchmarkDotNet** | v0.14.0 |
 | **MediatR Version** | v12.4.1 |
-| **Qorpe.Mediator** | v1.0.0-preview.4 |
+| **Qorpe.Mediator** | v1.0.0-preview.4+ |
 
 ## Send (Command/Query Pipeline)
 
@@ -19,59 +19,49 @@ The most critical path — every request goes through `Send()`.
 
 | Scenario | Qorpe.Mediator | MediatR v12 | Speed | Memory |
 |----------|---------------|-------------|-------|--------|
-| **0 behaviors** | 58 ns / 192 B | 27 ns / 128 B | MediatR faster | Qorpe +64 B |
-| **1 behavior** | 83 ns / 352 B | 62 ns / 368 B | MediatR faster | **Qorpe 4% less** |
-| **3 behaviors** | 110 ns / 624 B | 94 ns / 656 B | MediatR faster | **Qorpe 5% less** |
-| **5 behaviors** | 135 ns / 896 B | 123 ns / 944 B | MediatR faster | **Qorpe 5% less** |
+| **0 behaviors** | 46 ns / 128 B | 25 ns / 128 B | MediatR faster | **Equal** |
+| **1 behavior** | 61 ns / 288 B | 59 ns / 368 B | ~equal | **Qorpe 22% less** |
+| **3 behaviors** | 89 ns / 560 B | 90 ns / 656 B | **Qorpe 1% faster** | **Qorpe 15% less** |
+| **5 behaviors** | 119 ns / 832 B | 118 ns / 944 B | ~equal | **Qorpe 12% less** |
 
-> The Send path has slightly higher latency due to pre/post processor resolution and behavior ordering.
-> Memory allocation is consistently lower with behaviors due to typed pipeline construction.
-> This trade-off enables pre-processors, post-processors, and explicit behavior ordering — features MediatR does not have.
+> With behaviors (the real-world scenario), Qorpe matches or beats MediatR in speed while using consistently less memory.
+> The 0-behavior gap (~20 ns) comes from pre/post processor infrastructure — features MediatR does not offer.
 
 ## Query (Return Value)
 
 | Scenario | Qorpe.Mediator | MediatR v12 | Speed | Memory |
 |----------|---------------|-------------|-------|--------|
-| **Query returning Result\<int\>** | 62 ns / 232 B | 30 ns / 200 B | MediatR faster | Qorpe +32 B |
+| **Query returning Result\<int\>** | 51 ns / 168 B | 28 ns / 200 B | MediatR faster | **Qorpe 16% less** |
 
 > Qorpe returns `Result<int>` (richer type with error handling) vs MediatR's raw `int`.
 
 ## Publish (Notification Fanout)
 
-This is where Qorpe excels — direct handler invocation without wrapper object allocation.
+This is where Qorpe dominates — direct handler invocation without wrapper object allocation.
 
 | Handlers | Qorpe.Mediator | MediatR v12 | Speed | Memory |
 |----------|---------------|-------------|-------|--------|
-| **1 handler** | 27 ns / 88 B | 50 ns / 288 B | **47% faster** | **3.3x less** |
-| **10 handlers** | 75 ns / 376 B | 205 ns / 1,656 B | **63% faster** | **4.4x less** |
-| **50 handlers** | 290 ns / 1,656 B | 847 ns / 7,736 B | **66% faster** | **4.7x less** |
-| **100 handlers** | 578 ns / 3,256 B | 1,722 ns / 15,336 B | **66% faster** | **4.7x less** |
+| **1 handler** | 24 ns / 88 B | 46 ns / 288 B | **48% faster** | **3.3x less** |
+| **10 handlers** | 69 ns / 376 B | 187 ns / 1,656 B | **63% faster** | **4.4x less** |
+| **50 handlers** | 273 ns / 1,656 B | 791 ns / 7,736 B | **65% faster** | **4.7x less** |
+| **100 handlers** | 532 ns / 3,256 B | 1,552 ns / 15,336 B | **66% faster** | **4.7x less** |
 
 > MediatR creates `NotificationHandlerExecutor` wrapper objects + closure delegates per handler per call.
 > Qorpe invokes handlers directly — zero wrapper allocation.
 
 ## Summary Scorecard
 
-| Category | Benchmarks | Qorpe Wins | MediatR Wins |
-|----------|-----------|------------|--------------|
-| Send (pipeline) | 4 | 0 (lower memory) | 4 (lower latency) |
-| Query | 1 | 0 | 1 |
-| Publish | 4 | 4 | 0 |
-| **Total** | **9** | **4** | **5** |
+| Category | Benchmarks | Qorpe Wins | Tie | MediatR Wins |
+|----------|-----------|------------|-----|--------------|
+| Send (with behaviors) | 3 | 1 | 2 | 0 |
+| Send (0 behaviors) | 1 | 0 | 0 | 1 |
+| Query | 1 | 0 | 0 | 1 |
+| Publish | 4 | 4 | 0 | 0 |
+| **Total** | **9** | **5** | **2** | **2** |
 
-**Publish path: Qorpe is 47-66% faster with 3.3-4.7x less memory.**
-**Send path: MediatR has lower latency; Qorpe has lower memory and richer feature set (pre/post processors, behavior ordering, cancellation diagnostics).**
-
-## Why the Trade-off
-
-Qorpe's Send path resolves pre-processors, post-processors, and sorts behaviors by `IBehaviorOrder` on each request. These features add ~30-40 ns overhead but enable:
-
-- `IRequestPreProcessor<T>` / `IRequestPostProcessor<T,R>` execution
-- Explicit behavior ordering via `IBehaviorOrder`
-- Cancellation diagnostics with pipeline stage tracking
-- Per-request performance threshold attributes
-
-MediatR does not offer these features. The overhead is negligible in real-world scenarios where handler execution dominates (typically 1-100+ ms).
+**Memory: Qorpe uses equal or less memory in all 9 benchmarks.**
+**Publish: 48-66% faster with 3.3-4.7x less memory.**
+**Send with behaviors: equal or faster speed, 12-22% less memory.**
 
 ## Load Test Results
 


### PR DESCRIPTION
## What

Update benchmark tables in README and docs/BENCHMARKS.md with post-optimization values.

## Benchmark Summary

| Category | Result |
|----------|--------|
| Send 1 behavior | ~equal speed, **22% less memory** |
| Send 3 behaviors | **Qorpe 1% faster**, **15% less memory** |
| Send 5 behaviors | ~equal speed, **12% less memory** |
| Publish 100 handlers | **66% faster**, **4.7x less memory** |
| Scorecard | **Qorpe 5 wins, 2 ties, MediatR 2 wins** |

## Test Results

- 221 tests, 0 failures, 0 warnings