### PR TITLE
fix(aspnetcore): validate query parameters with descriptive error responses

### DIFF
--- a/src/Qorpe.Mediator.AspNetCore/Mapping/EndpointMapper.cs
+++ b/src/Qorpe.Mediator.AspNetCore/Mapping/EndpointMapper.cs
@@ -159,7 +159,16 @@ public static class EndpointMapper
 
             if (context.Request.Method == "GET")
             {
-                request = BindFromQueryAndRoute(context, requestType);
+                var (boundRequest, bindingErrors) = BindFromQueryAndRoute(context, requestType);
+                if (bindingErrors.Count > 0)
+                {
+                    return Microsoft.AspNetCore.Http.Results.Problem(
+                        statusCode: StatusCodes.Status400BadRequest,
+                        title: "Invalid Query Parameters",
+                        detail: string.Join("; ", bindingErrors),
+                        extensions: new Dictionary<string, object?> { ["errors"] = bindingErrors });
+                }
+                request = boundRequest;
             }
             else
             {
@@ -220,10 +229,11 @@ public static class EndpointMapper
         return Microsoft.AspNetCore.Http.Results.Ok(response);
     }
 
-    private static object BindFromQueryAndRoute(HttpContext context, Type requestType)
+    private static (object Instance, List<string> Errors) BindFromQueryAndRoute(HttpContext context, Type requestType)
     {
         var instance = Activator.CreateInstance(requestType)!;
         var properties = requestType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var errors = new List<string>();
 
         for (int i = 0; i < properties.Length; i++)
         {
@@ -242,10 +252,14 @@ public static class EndpointMapper
                 {
                     prop.SetValue(instance, converted);
                 }
+                else
+                {
+                    errors.Add($"Parameter '{prop.Name}' has invalid value '{value}' for type '{prop.PropertyType.Name}'.");
+                }
             }
         }
 
-        return instance;
+        return (instance, errors);
     }
 
     private static void BindRouteParameters(HttpContext context, object request, Type requestType)

--- a/tests/Qorpe.Mediator.UnitTests/AspNetCore/EndpointMapperTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/AspNetCore/EndpointMapperTests.cs
@@ -75,4 +75,25 @@ public class EndpointMapperConvertValueTests
         var result = InvokeConvertValue("true", typeof(bool));
         result.Should().Be(true);
     }
+
+    [Fact]
+    public void ConvertValue_InvalidInt_ShouldReturnNull()
+    {
+        var result = InvokeConvertValue("abc", typeof(int));
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ConvertValue_InvalidGuid_ShouldReturnNull()
+    {
+        var result = InvokeConvertValue("not-a-guid", typeof(Guid));
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ConvertValue_InvalidEnum_ShouldReturnNull()
+    {
+        var result = InvokeConvertValue("nonexistent", typeof(TestStatus));
+        result.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## What

Return 400 ProblemDetails when query parameter conversion fails, instead of silently defaulting.

## Why

Invalid query parameters were silently ignored — `?Page=abc` would set Page to 0 with no error.

## Changes

- `BindFromQueryAndRoute` returns `(object, List<string>)` tuple with binding errors
- Errors include parameter name, invalid value, and expected type
- 3 new tests for invalid conversions

Closes #42

## Test Results

- 224 tests, 0 failures, 0 warnings