### PR TITLE
perf(core): optimize Send path with per-container pipeline probe cache

### DIFF
--- a/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Qorpe.Mediator/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,9 @@ public static class ServiceCollectionExtensions
         // Register options for injection
         services.TryAddSingleton(options);
 
+        // Register pipeline probe cache for fast-path optimization (one per container)
+        services.TryAddSingleton<PipelineProbeCache>();
+
         // Register the mediator
         services.TryAddTransient<IMediator, Implementation.Mediator>();
         services.TryAddTransient<ISender>(sp => sp.GetRequiredService<IMediator>());

--- a/src/Qorpe.Mediator/Implementation/PipelineProbeCache.cs
+++ b/src/Qorpe.Mediator/Implementation/PipelineProbeCache.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+
+namespace Qorpe.Mediator.Implementation;
+
+/// <summary>
+/// Per-container cache that tracks whether each request type has pipeline elements
+/// (pre/post processors, behaviors). Registered as Singleton — each root container
+/// gets its own instance, ensuring independent behavior resolution across containers.
+/// Thread-safe via ConcurrentDictionary.
+/// </summary>
+internal sealed class PipelineProbeCache
+{
+    private readonly ConcurrentDictionary<Type, bool> _handlerOnlyFlags = new();
+
+    /// <summary>
+    /// Checks if the pipeline state for a request type has been probed and cached.
+    /// </summary>
+    /// <param name="requestType">The concrete request type.</param>
+    /// <param name="isHandlerOnly">True if the request type has no processors or behaviors.</param>
+    /// <returns>True if the result was found in cache.</returns>
+    public bool TryGetHandlerOnly(Type requestType, out bool isHandlerOnly)
+        => _handlerOnlyFlags.TryGetValue(requestType, out isHandlerOnly);
+
+    /// <summary>
+    /// Caches whether a request type is handler-only (no processors or behaviors).
+    /// Uses TryAdd — first write wins, subsequent writes for the same type are ignored.
+    /// </summary>
+    public void SetHandlerOnly(Type requestType, bool isHandlerOnly)
+        => _handlerOnlyFlags.TryAdd(requestType, isHandlerOnly);
+
+    /// <summary>
+    /// Clears the cache. For testing purposes only.
+    /// </summary>
+    internal void Clear() => _handlerOnlyFlags.Clear();
+}

--- a/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
+++ b/src/Qorpe.Mediator/Implementation/RequestHandlerWrapper.cs
@@ -31,6 +31,22 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
 
     public ValueTask<TResponse> HandleTyped(TRequest request, IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
+        // Check per-container pipeline probe cache for fast path
+        var probeCache = serviceProvider.GetService<PipelineProbeCache>();
+        if (probeCache != null && probeCache.TryGetHandlerOnly(typeof(TRequest), out var isHandlerOnly) && isHandlerOnly)
+        {
+            // FAST PATH: no processors, no behaviors — 1 DI call, no closure, no delegate
+            var handler = serviceProvider.GetService<IRequestHandler<TRequest, TResponse>>()
+                ?? throw new HandlerNotFoundException(typeof(TRequest));
+            return handler.Handle(request, cancellationToken);
+        }
+
+        return HandleWithPipeline(request, serviceProvider, cancellationToken, probeCache);
+    }
+
+    private ValueTask<TResponse> HandleWithPipeline(TRequest request, IServiceProvider serviceProvider,
+        CancellationToken cancellationToken, PipelineProbeCache? probeCache)
+    {
         // Resolve handler — fully typed, single DI call, zero reflection
         var handler = serviceProvider.GetService<IRequestHandler<TRequest, TResponse>>();
         if (handler is null)
@@ -64,6 +80,8 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
         // Fast path: no behaviors registered
         if (behaviors is null)
         {
+            // Cache the probe result for subsequent calls
+            probeCache?.SetHandlerOnly(typeof(TRequest), !hasPreProcessors && !hasPostProcessors);
             return handlerDelegate();
         }
 
@@ -81,6 +99,8 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
             behaviorCount = col.Count;
             if (behaviorCount == 0)
             {
+                // Cache the probe result for subsequent calls
+                probeCache?.SetHandlerOnly(typeof(TRequest), !hasPreProcessors && !hasPostProcessors);
                 return handlerDelegate();
             }
             behaviorArray = new IPipelineBehavior<TRequest, TResponse>[behaviorCount];
@@ -95,8 +115,13 @@ internal sealed class RequestHandlerWrapper<TRequest, TResponse> : RequestHandle
 
         if (behaviorCount == 0)
         {
+            // Cache the probe result for subsequent calls
+            probeCache?.SetHandlerOnly(typeof(TRequest), !hasPreProcessors && !hasPostProcessors);
             return handlerDelegate();
         }
+
+        // Has pipeline elements — cache as non-handler-only
+        probeCache?.SetHandlerOnly(typeof(TRequest), false);
 
         // Sort by IBehaviorOrder.Order if any behaviors implement it
         SortBehaviorsByOrder(behaviorArray, behaviorCount);

--- a/tests/Qorpe.Mediator.UnitTests/Core/PipelineProbeCacheTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Core/PipelineProbeCacheTests.cs
@@ -1,0 +1,391 @@
+using Microsoft.Extensions.DependencyInjection;
+using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.DependencyInjection;
+using Qorpe.Mediator.Results;
+
+namespace Qorpe.Mediator.UnitTests.Core;
+
+/// <summary>
+/// Tests for the per-container pipeline probe cache optimization.
+/// Verifies that the fast path (handler-only) is taken when appropriate
+/// and that the full pipeline path is taken when behaviors/processors exist.
+/// </summary>
+public class PipelineProbeCacheTests
+{
+    // ===== Types for testing =====
+    public sealed record FastPathCommand(string Data) : ICommand<Result>;
+    public sealed class FastPathCommandHandler : ICommandHandler<FastPathCommand>
+    {
+        public static int CallCount;
+        public ValueTask<Result> Handle(FastPathCommand request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref CallCount);
+            return new ValueTask<Result>(Result.Success());
+        }
+    }
+
+    public sealed record FastPathQuery(int Id) : IQuery<Result<string>>;
+    public sealed class FastPathQueryHandler : IQueryHandler<FastPathQuery, Result<string>>
+    {
+        public static int CallCount;
+        public ValueTask<Result<string>> Handle(FastPathQuery request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref CallCount);
+            return new ValueTask<Result<string>>(Result<string>.Success($"Item-{request.Id}"));
+        }
+    }
+
+    public sealed class CountingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        public static int ExecutionCount;
+        public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref ExecutionCount);
+            return await next().ConfigureAwait(false);
+        }
+    }
+
+    public sealed class CountingPreProcessor<TRequest> : IRequestPreProcessor<TRequest>
+        where TRequest : notnull
+    {
+        public static int ExecutionCount;
+        public ValueTask Process(TRequest request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref ExecutionCount);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class CountingPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        public static int ExecutionCount;
+        public ValueTask Process(TRequest request, TResponse response, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref ExecutionCount);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // ===== Fast path tests =====
+
+    [Fact]
+    public async Task HandlerOnly_Should_Take_FastPath_And_Return_Correct_Result()
+    {
+        FastPathCommandHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new FastPathCommand("test"));
+
+        result.IsSuccess.Should().BeTrue();
+        FastPathCommandHandler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandlerOnly_Should_Work_Correctly_On_Repeated_Calls()
+    {
+        FastPathCommandHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        // First call populates cache, subsequent calls use fast path
+        for (int i = 0; i < 10; i++)
+        {
+            var result = await mediator.Send(new FastPathCommand($"call-{i}"));
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        FastPathCommandHandler.CallCount.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task Query_HandlerOnly_Should_Take_FastPath()
+    {
+        FastPathQueryHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new FastPathQuery(42));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("Item-42");
+        FastPathQueryHandler.CallCount.Should().Be(1);
+    }
+
+    // ===== Behavior pipeline tests =====
+
+    [Fact]
+    public async Task WithBehaviors_Should_NOT_Take_FastPath()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        // Call multiple times
+        for (int i = 0; i < 5; i++)
+        {
+            await mediator.Send(new FastPathCommand($"call-{i}"));
+        }
+
+        FastPathCommandHandler.CallCount.Should().Be(5);
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(5,
+            "behavior must execute on every call, cache must not skip it");
+    }
+
+    [Fact]
+    public async Task WithPreProcessor_Should_NOT_Take_FastPath()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingPreProcessor<FastPathCommand>.ExecutionCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services.AddTransient(typeof(IRequestPreProcessor<>), typeof(CountingPreProcessor<>));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        for (int i = 0; i < 3; i++)
+        {
+            await mediator.Send(new FastPathCommand($"call-{i}"));
+        }
+
+        FastPathCommandHandler.CallCount.Should().Be(3);
+        CountingPreProcessor<FastPathCommand>.ExecutionCount.Should().Be(3,
+            "pre-processor must execute on every call");
+    }
+
+    [Fact]
+    public async Task WithPostProcessor_Should_NOT_Take_FastPath()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingPostProcessor<FastPathCommand, Result>.ExecutionCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services.AddTransient(typeof(IRequestPostProcessor<,>), typeof(CountingPostProcessor<,>));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        for (int i = 0; i < 3; i++)
+        {
+            await mediator.Send(new FastPathCommand($"call-{i}"));
+        }
+
+        FastPathCommandHandler.CallCount.Should().Be(3);
+        CountingPostProcessor<FastPathCommand, Result>.ExecutionCount.Should().Be(3,
+            "post-processor must execute on every call");
+    }
+
+    // ===== Per-container isolation tests =====
+
+    [Fact]
+    public async Task Different_Containers_Must_Have_Independent_Cache()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+
+        // Container 1: NO behaviors (handler-only)
+        var services1 = new ServiceCollection();
+        services1.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        var mediator1 = services1.BuildServiceProvider().GetRequiredService<IMediator>();
+
+        // Container 2: WITH behaviors
+        var services2 = new ServiceCollection();
+        services2.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services2.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+        services2.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+        var mediator2 = services2.BuildServiceProvider().GetRequiredService<IMediator>();
+
+        // Warm up container 1 (should cache as handler-only)
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+        await mediator1.Send(new FastPathCommand("no-behaviors"));
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(0);
+
+        // Container 2 must still execute behaviors despite container 1's cache
+        await mediator2.Send(new FastPathCommand("with-behaviors"));
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(2,
+            "container 2 has 2 behaviors — must NOT be affected by container 1's handler-only cache");
+    }
+
+    [Fact]
+    public async Task Different_Containers_Reverse_Order_Must_Have_Independent_Cache()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+
+        // Container 1: WITH behaviors (warmed first)
+        var services1 = new ServiceCollection();
+        services1.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services1.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+        var mediator1 = services1.BuildServiceProvider().GetRequiredService<IMediator>();
+
+        // Container 2: NO behaviors
+        var services2 = new ServiceCollection();
+        services2.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        var mediator2 = services2.BuildServiceProvider().GetRequiredService<IMediator>();
+
+        // Warm up container 1 (should cache as has-pipeline)
+        await mediator1.Send(new FastPathCommand("with-behaviors"));
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(1);
+
+        // Container 2 must still work without behaviors
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+        await mediator2.Send(new FastPathCommand("no-behaviors"));
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(0,
+            "container 2 has no behaviors — must NOT be affected by container 1's cache");
+    }
+
+    // ===== Scoped DI tests =====
+
+    [Fact]
+    public async Task Scoped_ServiceProviders_Should_Share_Cache()
+    {
+        FastPathCommandHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var rootSp = services.BuildServiceProvider();
+
+        // Call from multiple scopes — all should use the same cache
+        for (int i = 0; i < 5; i++)
+        {
+            using var scope = rootSp.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var result = await mediator.Send(new FastPathCommand($"scope-{i}"));
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        FastPathCommandHandler.CallCount.Should().Be(5);
+    }
+
+    // ===== Concurrent access tests =====
+
+    [Fact]
+    public async Task Concurrent_Sends_Should_Be_ThreadSafe()
+    {
+        FastPathCommandHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var sp = services.BuildServiceProvider();
+
+        const int concurrency = 100;
+        var tasks = new Task[concurrency];
+        for (int i = 0; i < concurrency; i++)
+        {
+            var idx = i;
+            tasks[i] = Task.Run(async () =>
+            {
+                using var scope = sp.CreateScope();
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+                var result = await mediator.Send(new FastPathCommand($"concurrent-{idx}"));
+                result.IsSuccess.Should().BeTrue();
+            });
+        }
+
+        await Task.WhenAll(tasks);
+        FastPathCommandHandler.CallCount.Should().Be(concurrency);
+    }
+
+    [Fact]
+    public async Task Concurrent_Sends_With_Behaviors_Should_Be_ThreadSafe()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+
+        var sp = services.BuildServiceProvider();
+
+        const int concurrency = 100;
+        var tasks = new Task[concurrency];
+        for (int i = 0; i < concurrency; i++)
+        {
+            var idx = i;
+            tasks[i] = Task.Run(async () =>
+            {
+                using var scope = sp.CreateScope();
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+                var result = await mediator.Send(new FastPathCommand($"concurrent-{idx}"));
+                result.IsSuccess.Should().BeTrue();
+            });
+        }
+
+        await Task.WhenAll(tasks);
+        FastPathCommandHandler.CallCount.Should().Be(concurrency);
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(concurrency);
+    }
+
+    // ===== First call correctness =====
+
+    [Fact]
+    public async Task First_Call_Must_Return_Correct_Result_Before_Cache_Is_Populated()
+    {
+        FastPathCommandHandler.CallCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        // Very first call (cache is cold)
+        var result = await mediator.Send(new FastPathCommand("first-ever"));
+
+        result.IsSuccess.Should().BeTrue();
+        FastPathCommandHandler.CallCount.Should().Be(1);
+    }
+
+    // ===== Mixed scenarios =====
+
+    [Fact]
+    public async Task Multiple_Request_Types_Should_Have_Independent_Cache_Entries()
+    {
+        FastPathCommandHandler.CallCount = 0;
+        FastPathQueryHandler.CallCount = 0;
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount = 0;
+
+        var services = new ServiceCollection();
+        services.AddQorpeMediator(cfg => cfg.RegisterServicesFromAssembly(typeof(PipelineProbeCacheTests).Assembly));
+        // Register behavior only for commands (open generic applies to both, but that's fine for this test)
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CountingBehavior<,>));
+
+        var sp = services.BuildServiceProvider();
+        var mediator = sp.GetRequiredService<IMediator>();
+
+        // Both types go through the behavior (open generic registration)
+        await mediator.Send(new FastPathCommand("cmd"));
+        await mediator.Send(new FastPathQuery(1));
+
+        FastPathCommandHandler.CallCount.Should().Be(1);
+        FastPathQueryHandler.CallCount.Should().Be(1);
+        // Open generic behavior applies to both
+        CountingBehavior<FastPathCommand, Result>.ExecutionCount.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #57

- Add `PipelineProbeCache` (Singleton per container) that caches whether each request type has pipeline elements (pre/post processors, behaviors)
- After the first call per request type, `HandleTyped` takes a fast path: 1 DI call (handler only), no closure allocation, no delegate indirection
- Eliminates 3 unnecessary `GetService` calls on the hot path for handler-only request types

## Expected Performance Impact

| Scenario | Before | After (expected) |
|----------|--------|-------------------|
| Send (0 behaviors) | 46ns / 128B | ~25ns / 128B |
| Query | 51ns / 168B | ~28ns / 168B |
| Send (1+ behaviors) | unchanged | unchanged |
| Publish | unchanged | unchanged |

## Safety

- `PipelineProbeCache` is **Singleton per container** — different containers have independent caches
- Fast path only activates after the first call proves no pipeline elements exist
- Full pipeline path is the existing code, unchanged
- 13 new tests covering: fast path correctness, behavior/processor non-skipping, per-container isolation, scoped DI, concurrency

## Test plan

- [x] All 207 unit tests pass
- [x] All 21 integration tests pass
- [x] All 18 load tests pass
- [ ] Run benchmarks to confirm performance improvement