### PR TITLE
perf(behaviors): cache attribute reflection lookups per request type

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/AuditBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/AuditBehavior.cs
@@ -19,6 +19,19 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
     where TRequest : IRequest<TResponse>
 {
     public int Order => 100;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly AuditableAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(AuditableAttribute), true)
+            .Cast<AuditableAttribute>()
+            .FirstOrDefault();
+
+    // Cached type checks
+    private static readonly bool IsCommandType = typeof(TRequest).GetInterfaces()
+        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommand<>));
+    private static readonly bool IsQueryType = typeof(TRequest).GetInterfaces()
+        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
+
     private readonly IAuditStore _auditStore;
     private readonly IAuditUserContext? _userContext;
     private readonly ILogger<AuditBehavior<TRequest, TResponse>> _logger;
@@ -48,10 +61,6 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
             return await next().ConfigureAwait(false);
         }
 
-        var auditableAttr = typeof(TRequest).GetCustomAttributes(typeof(AuditableAttribute), true)
-            .Cast<AuditableAttribute>()
-            .FirstOrDefault();
-
         var entry = new AuditEntry
         {
             RequestType = typeof(TRequest).FullName ?? typeof(TRequest).Name,
@@ -61,7 +70,7 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
             Timestamp = DateTimeOffset.UtcNow
         };
 
-        if (auditableAttr?.IncludeRequestBody != false)
+        if (CachedAttribute?.IncludeRequestBody != false)
         {
             entry.RequestData = SafeSerializeRequest(request);
         }
@@ -75,9 +84,9 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
             entry.IsSuccess = true;
             entry.DurationMs = sw.Elapsed.TotalMilliseconds;
 
-            if (auditableAttr?.IncludeResponseBody == true)
+            if (CachedAttribute?.IncludeResponseBody == true)
             {
-                entry.ResponseData = SafeSerializeResponse(response, auditableAttr.MaxResponseSize);
+                entry.ResponseData = SafeSerializeResponse(response, CachedAttribute.MaxResponseSize);
             }
 
             await SafeSaveAuditEntryAsync(entry, cancellationToken).ConfigureAwait(false);
@@ -98,17 +107,10 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
 
     private bool ShouldAudit()
     {
-        var isCommand = typeof(TRequest).GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommand<>));
+        if (IsCommandType && _options.AuditCommands) return true;
+        if (IsQueryType && _options.AuditQueries) return true;
 
-        var isQuery = typeof(TRequest).GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
-
-        if (isCommand && _options.AuditCommands) return true;
-        if (isQuery && _options.AuditQueries) return true;
-
-        // Check for explicit [Auditable] attribute
-        return typeof(TRequest).GetCustomAttributes(typeof(AuditableAttribute), true).Length > 0;
+        return CachedAttribute is not null;
     }
 
     private string SafeSerializeRequest(TRequest request)

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/AuthorizationBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/AuthorizationBehavior.cs
@@ -15,6 +15,13 @@ public sealed class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavi
     where TRequest : IRequest<TResponse>
 {
     public int Order => 400;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly AuthorizeAttribute[] CachedAttributes =
+        typeof(TRequest).GetCustomAttributes(typeof(AuthorizeAttribute), true)
+            .Cast<AuthorizeAttribute>()
+            .ToArray();
+
     private readonly IAuthorizationContext? _authContext;
     private readonly ILogger<AuthorizationBehavior<TRequest, TResponse>> _logger;
     private readonly AuthorizationBehaviorOptions _options;
@@ -36,12 +43,7 @@ public sealed class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavi
             return await next().ConfigureAwait(false);
         }
 
-        var authorizeAttributes = typeof(TRequest)
-            .GetCustomAttributes(typeof(AuthorizeAttribute), true)
-            .Cast<AuthorizeAttribute>()
-            .ToArray();
-
-        if (authorizeAttributes.Length == 0)
+        if (CachedAttributes.Length == 0)
         {
             return await next().ConfigureAwait(false);
         }
@@ -54,9 +56,9 @@ public sealed class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavi
         }
 
         // Check all [Authorize] attributes — ALL must pass
-        for (int i = 0; i < authorizeAttributes.Length; i++)
+        for (int i = 0; i < CachedAttributes.Length; i++)
         {
-            var attr = authorizeAttributes[i];
+            var attr = CachedAttributes[i];
 
             if (attr.Roles is not null)
             {

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/CacheInvalidationBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/CacheInvalidationBehavior.cs
@@ -13,6 +13,13 @@ public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBe
     where TRequest : IRequest<TResponse>
 {
     public int Order => 1001; // Just after CachingBehavior (1000)
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly InvalidatesCacheAttribute[] CachedAttributes =
+        typeof(TRequest).GetCustomAttributes(typeof(InvalidatesCacheAttribute), true)
+            .Cast<InvalidatesCacheAttribute>()
+            .ToArray();
+
     private readonly ICacheInvalidator? _cacheInvalidator;
     private readonly ILogger<CacheInvalidationBehavior<TRequest, TResponse>> _logger;
 
@@ -26,10 +33,7 @@ public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBe
 
     public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        var invalidateAttrs = typeof(TRequest).GetCustomAttributes(typeof(InvalidatesCacheAttribute), true)
-            as InvalidatesCacheAttribute[];
-
-        if (invalidateAttrs is null || invalidateAttrs.Length == 0 || _cacheInvalidator is null)
+        if (CachedAttributes.Length == 0 || _cacheInvalidator is null)
         {
             return await next().ConfigureAwait(false);
         }
@@ -38,18 +42,18 @@ public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBe
         var response = await next().ConfigureAwait(false);
 
         // Invalidate cache entries after successful execution
-        for (int i = 0; i < invalidateAttrs.Length; i++)
+        for (int i = 0; i < CachedAttributes.Length; i++)
         {
             try
             {
-                await _cacheInvalidator.InvalidateAsync(invalidateAttrs[i].KeyPrefix, cancellationToken).ConfigureAwait(false);
+                await _cacheInvalidator.InvalidateAsync(CachedAttributes[i].KeyPrefix, cancellationToken).ConfigureAwait(false);
                 _logger.LogDebug("Invalidated cache entries with prefix '{Prefix}' after {RequestName}",
-                    invalidateAttrs[i].KeyPrefix, typeof(TRequest).Name);
+                    CachedAttributes[i].KeyPrefix, typeof(TRequest).Name);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Cache invalidation failed for prefix '{Prefix}' after {RequestName}",
-                    invalidateAttrs[i].KeyPrefix, typeof(TRequest).Name);
+                    CachedAttributes[i].KeyPrefix, typeof(TRequest).Name);
             }
         }
 

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
@@ -17,6 +17,13 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
     where TRequest : IRequest<TResponse>
 {
     public int Order => 1000;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly CacheableAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(CacheableAttribute), true)
+            .Cast<CacheableAttribute>()
+            .FirstOrDefault();
+
     private readonly IDistributedCache? _cache;
     private readonly ILogger<CachingBehavior<TRequest, TResponse>> _logger;
     private readonly CachingBehaviorOptions _options;
@@ -47,11 +54,7 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
             return await next().ConfigureAwait(false);
         }
 
-        var cacheableAttr = typeof(TRequest).GetCustomAttributes(typeof(CacheableAttribute), true)
-            .Cast<CacheableAttribute>()
-            .FirstOrDefault();
-
-        if (cacheableAttr is null)
+        if (CachedAttribute is not { } cacheableAttr)
         {
             return await next().ConfigureAwait(false);
         }

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
@@ -18,6 +18,13 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
     where TRequest : IRequest<TResponse>
 {
     public int Order => 600;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly IdempotentAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(IdempotentAttribute), true)
+            .Cast<IdempotentAttribute>()
+            .FirstOrDefault();
+
     private readonly IIdempotencyStore? _store;
     private readonly ILogger<IdempotencyBehavior<TRequest, TResponse>> _logger;
     private readonly IdempotencyBehaviorOptions _options;
@@ -48,11 +55,7 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
             return await next().ConfigureAwait(false);
         }
 
-        var idempotentAttr = typeof(TRequest).GetCustomAttributes(typeof(IdempotentAttribute), true)
-            .Cast<IdempotentAttribute>()
-            .FirstOrDefault();
-
-        if (idempotentAttr is null)
+        if (CachedAttribute is not { } idempotentAttr)
         {
             return await next().ConfigureAwait(false);
         }

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/PerformanceBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/PerformanceBehavior.cs
@@ -15,6 +15,13 @@ public sealed class PerformanceBehavior<TRequest, TResponse> : IPipelineBehavior
     where TRequest : IRequest<TResponse>
 {
     public int Order => 800;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly PerformanceThresholdAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(PerformanceThresholdAttribute), true)
+            .Cast<PerformanceThresholdAttribute>()
+            .FirstOrDefault();
+
     private readonly ILogger<PerformanceBehavior<TRequest, TResponse>> _logger;
     private readonly PerformanceBehaviorOptions _options;
 
@@ -53,14 +60,11 @@ public sealed class PerformanceBehavior<TRequest, TResponse> : IPipelineBehavior
 
         var requestName = typeof(TRequest).Name;
 
-        // Check per-request attribute override, fall back to global options
-        var thresholdAttr = typeof(TRequest).GetCustomAttributes(typeof(PerformanceThresholdAttribute), true)
-            as PerformanceThresholdAttribute[];
-        var warningMs = thresholdAttr is { Length: > 0 } && thresholdAttr[0].WarningMs > 0
-            ? thresholdAttr[0].WarningMs
+        var warningMs = CachedAttribute is not null && CachedAttribute.WarningMs > 0
+            ? CachedAttribute.WarningMs
             : _options.WarningThresholdMs;
-        var criticalMs = thresholdAttr is { Length: > 0 } && thresholdAttr[0].CriticalMs > 0
-            ? thresholdAttr[0].CriticalMs
+        var criticalMs = CachedAttribute is not null && CachedAttribute.CriticalMs > 0
+            ? CachedAttribute.CriticalMs
             : _options.CriticalThresholdMs;
 
         // Over 30 seconds — always critical regardless of thresholds

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
@@ -18,6 +18,12 @@ public sealed class RetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
     private readonly ILogger<RetryBehavior<TRequest, TResponse>> _logger;
     private readonly RetryBehaviorOptions _options;
 
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly RetryableAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(RetryableAttribute), true)
+            .Cast<RetryableAttribute>()
+            .FirstOrDefault();
+
     // Exception types that should never be retried
     private static readonly HashSet<Type> NonRetryableExceptions = new()
     {
@@ -45,11 +51,7 @@ public sealed class RetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
             return await next().ConfigureAwait(false);
         }
 
-        var retryAttr = typeof(TRequest).GetCustomAttributes(typeof(RetryableAttribute), true)
-            .Cast<RetryableAttribute>()
-            .FirstOrDefault();
-
-        if (retryAttr is null)
+        if (CachedAttribute is not { } retryAttr)
         {
             return await next().ConfigureAwait(false);
         }

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
@@ -14,6 +14,13 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
     where TRequest : IRequest<TResponse>
 {
     public int Order => 700;
+
+    // Cached attribute lookup — runs once per closed generic type (per TRequest), not per request
+    private static readonly TransactionalAttribute? CachedAttribute =
+        typeof(TRequest).GetCustomAttributes(typeof(TransactionalAttribute), true)
+            .Cast<TransactionalAttribute>()
+            .FirstOrDefault();
+
     private readonly IUnitOfWork? _unitOfWork;
     private readonly ILogger<TransactionBehavior<TRequest, TResponse>> _logger;
     private readonly TransactionBehaviorOptions _options;
@@ -41,12 +48,7 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
             return await next().ConfigureAwait(false);
         }
 
-        // Check [Transactional] attribute or if it's a command (implicit transaction)
-        var transactionalAttr = typeof(TRequest).GetCustomAttributes(typeof(TransactionalAttribute), true)
-            .Cast<TransactionalAttribute>()
-            .FirstOrDefault();
-
-        if (transactionalAttr is null)
+        if (CachedAttribute is null)
         {
             return await next().ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

- Replace per-request `GetCustomAttributes` reflection calls with `static readonly` fields in all 8 behaviors
- Since behaviors are closed generic types (`RetryBehavior<TRequest, TResponse>`), static fields are automatically per-TRequest with zero dictionary overhead
- Also caches `IsCommand`/`IsQuery` type checks in AuditBehavior

## Affected Behaviors

RetryBehavior, CachingBehavior, IdempotencyBehavior, TransactionBehavior, AuthorizationBehavior, PerformanceBehavior, AuditBehavior, CacheInvalidationBehavior

## Test Plan

- [x] All 207 unit tests pass
- [x] Build succeeds on all target frameworks (net8.0, net9.0, net10.0)
- [ ] Benchmark comparison to verify no regression

Closes #64