### PR TITLE
perf(behaviors): cache IsCommand/IsQuery interface type checks

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
@@ -28,6 +28,10 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
     private readonly ILogger<CachingBehavior<TRequest, TResponse>> _logger;
     private readonly CachingBehaviorOptions _options;
 
+    // Cached type check — runs once per closed generic type, not per request
+    private static readonly bool IsCommandType = typeof(TRequest).GetInterfaces()
+        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommand<>));
+
     // Bounded lock pool for stampede prevention with automatic eviction
     private static readonly BoundedLockPool LockPool = new();
 
@@ -49,7 +53,7 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
         }
 
         // Skip commands — caching is for queries only
-        if (IsCommand())
+        if (IsCommandType)
         {
             return await next().ConfigureAwait(false);
         }
@@ -135,9 +139,4 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
         return $"{typeName}:{json}";
     }
 
-    private static bool IsCommand()
-    {
-        return typeof(TRequest).GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommand<>));
-    }
 }

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/IdempotencyBehavior.cs
@@ -29,6 +29,10 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
     private readonly ILogger<IdempotencyBehavior<TRequest, TResponse>> _logger;
     private readonly IdempotencyBehaviorOptions _options;
 
+    // Cached type check — runs once per closed generic type, not per request
+    private static readonly bool IsQueryType = typeof(TRequest).GetInterfaces()
+        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
+
     // Per-key lock pool shared across all IdempotencyBehavior instances
     private static readonly BoundedLockPool KeyLocks = new();
 
@@ -50,7 +54,7 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
         }
 
         // Skip queries
-        if (IsQuery())
+        if (IsQueryType)
         {
             return await next().ConfigureAwait(false);
         }
@@ -123,9 +127,4 @@ public sealed class IdempotencyBehavior<TRequest, TResponse> : IPipelineBehavior
         return Convert.ToHexString(hash);
     }
 
-    private static bool IsQuery()
-    {
-        return typeof(TRequest).GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
-    }
 }

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
@@ -21,6 +21,10 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
             .Cast<TransactionalAttribute>()
             .FirstOrDefault();
 
+    // Cached type check — runs once per closed generic type, not per request
+    private static readonly bool IsQueryType = typeof(TRequest).GetInterfaces()
+        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
+
     private readonly IUnitOfWork? _unitOfWork;
     private readonly ILogger<TransactionBehavior<TRequest, TResponse>> _logger;
     private readonly TransactionBehaviorOptions _options;
@@ -43,7 +47,7 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
         }
 
         // Skip queries — transactions are for commands only
-        if (IsQuery())
+        if (IsQueryType)
         {
             return await next().ConfigureAwait(false);
         }
@@ -106,9 +110,4 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
         }
     }
 
-    private static bool IsQuery()
-    {
-        return typeof(TRequest).GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
-    }
 }


### PR DESCRIPTION
## Summary

- Replace per-request `GetInterfaces().Any()` reflection calls with `static readonly bool` fields
- Affected: CachingBehavior, IdempotencyBehavior, TransactionBehavior
- Removes now-unused `IsCommand()`/`IsQuery()` methods

## Test Plan

- [x] All 207 unit tests pass
- [x] Build succeeds on all target frameworks

Closes #66