### PR TITLE
fix(behaviors): fix unreachable TaskCanceledException retry in RetryBehavior

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/RetryBehavior.cs
@@ -133,9 +133,11 @@ public sealed class RetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
         }
 
         // Retryable: TimeoutException, HttpRequestException, TaskCanceledException (non-user)
-        return ex is TimeoutException
-            or HttpRequestException
-            or (TaskCanceledException and not OperationCanceledException);
+        // Note: TaskCanceledException inherits from OperationCanceledException, so we check
+        // whether the exception's token differs from the user's token (HttpClient timeouts
+        // set CancellationToken.None, not the user's token).
+        return ex is TimeoutException or HttpRequestException
+            || (ex is TaskCanceledException tce && tce.CancellationToken != cancellationToken);
     }
 
     private static int CalculateDelay(int attempt, int initialDelayMs, bool useExponentialBackoff, int maxBackoffMs)


### PR DESCRIPTION
## Summary

- The pattern `TaskCanceledException and not OperationCanceledException` was always `false` because `TaskCanceledException` inherits from `OperationCanceledException`
- HttpClient timeout exceptions (which manifest as `TaskCanceledException` with `CancellationToken.None`) were never retried
- Replace with token comparison to correctly distinguish HttpClient timeouts (retryable) from user cancellation (not retryable)

## Test Plan

- [x] All 207 unit tests pass
- [x] Build succeeds on all target frameworks

Closes #68