### PR TITLE
perf(behaviors): optimize cache key generation with SHA256 hash

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/CachingBehavior.cs
@@ -1,4 +1,5 @@
-using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -136,7 +137,8 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
     {
         var typeName = prefix ?? typeof(TRequest).FullName ?? typeof(TRequest).Name;
         var json = JsonSerializer.Serialize(request);
-        return $"{typeName}:{json}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return $"{typeName}:{Convert.ToHexString(hash)}";
     }
 
 }


### PR DESCRIPTION
## Summary

- Replace raw JSON string cache keys with SHA256 hash for fixed-length keys
- Prevents excessively long keys with large request payloads
- Aligns with IdempotencyBehavior's existing approach

## Test Plan

- [x] All 207 unit tests pass
- [x] Build succeeds on all target frameworks

Closes #70