### PR TITLE
feat(dashboard): centralize version and benchmark data in config.ts

### DIFF
--- a/dashboard/src/components/sections/BenchmarksSection.tsx
+++ b/dashboard/src/components/sections/BenchmarksSection.tsx
@@ -14,6 +14,7 @@ import {
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import { Card } from "@/components/ui/Card";
 import { sendBenchmarks, publishBenchmarks, memoryBenchmarks } from "@/data/benchmarks";
+import { benchmarkHighlights } from "@/data/config";
 
 type Tab = "send" | "publish" | "memory";
 
@@ -176,15 +177,15 @@ export function BenchmarksSection() {
           {/* Highlight cards */}
           <div className="grid sm:grid-cols-3 gap-4 mt-6">
             <Card variant="glass" className="text-center">
-              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">~66%</div>
+              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">{benchmarkHighlights.fasterPercent}</div>
               <div className="text-sm text-text-secondary mt-1">{t("benchmarks.faster")}</div>
             </Card>
             <Card variant="glass" className="text-center">
-              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">4.7x</div>
+              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">{benchmarkHighlights.lessMemoryMultiplier}</div>
               <div className="text-sm text-text-secondary mt-1">{t("benchmarks.lessMemory")}</div>
             </Card>
             <Card variant="glass" className="text-center">
-              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">0 alloc</div>
+              <div className="text-2xl font-bold text-brand-600 dark:text-brand-400">{benchmarkHighlights.publishHotPath}</div>
               <div className="text-sm text-text-secondary mt-1">Publish Hot Path</div>
             </Card>
           </div>

--- a/dashboard/src/components/sections/HeroSection.tsx
+++ b/dashboard/src/components/sections/HeroSection.tsx
@@ -12,12 +12,13 @@ function GithubIcon({ className }: { className?: string }) {
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { CodeBlock } from "@/components/ui/CodeBlock";
+import { heroStats, APP_VERSION } from "@/data/config";
 
 const stats = [
-  { key: "fasterPublish", value: "66%", icon: Zap },
-  { key: "lessMemory", value: "4.7x", icon: Cpu },
-  { key: "pipelineBehaviors", value: "11", icon: Layers },
-  { key: "testsCoverage", value: "221", icon: FlaskConical },
+  { key: "fasterPublish", value: heroStats.fasterPublish, icon: Zap },
+  { key: "lessMemory", value: heroStats.lessMemory, icon: Cpu },
+  { key: "pipelineBehaviors", value: heroStats.pipelineBehaviors, icon: Layers },
+  { key: "testsCoverage", value: heroStats.testsCoverage, icon: FlaskConical },
 ];
 
 export function HeroSection() {
@@ -43,7 +44,7 @@ export function HeroSection() {
           >
             <Badge variant="brand" className="mb-6">
               <span className="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse" />
-              {t("hero.badge")}
+              v{APP_VERSION} {t("hero.badge")}
             </Badge>
 
             <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-6 break-words">

--- a/dashboard/src/data/benchmarks.ts
+++ b/dashboard/src/data/benchmarks.ts
@@ -1,58 +1,31 @@
+/**
+ * Benchmark data from BenchmarkDotNet runs.
+ * Values in nanoseconds (ns) for send/publish, bytes (B) for memory.
+ * Update these after running: cd tests/Qorpe.Mediator.Benchmarks && dotnet run -c Release
+ */
+
 export const sendBenchmarks = [
-  {
-    name: "Send (Simple)",
-    qorpe: 297.8,
-    mediatr: 303.9,
-  },
-  {
-    name: "Send (Complex)",
-    qorpe: 316.5,
-    mediatr: 337.2,
-  },
-  {
-    name: "Send (with Pipeline)",
-    qorpe: 1_120,
-    mediatr: 1_200,
-  },
+  { name: "0 Behaviors", qorpe: 25, mediatr: 24 },
+  { name: "1 Behavior", qorpe: 64, mediatr: 58 },
+  { name: "2 Behaviors", qorpe: 74, mediatr: 74 },
+  { name: "4 Behaviors", qorpe: 102, mediatr: 104 },
+  { name: "8 Behaviors", qorpe: 160, mediatr: 164 },
+  { name: "16 Behaviors", qorpe: 270, mediatr: 280 },
+  { name: "32 Behaviors", qorpe: 490, mediatr: 516 },
 ];
 
 export const publishBenchmarks = [
-  {
-    name: "Publish (1 Handler)",
-    qorpe: 397.5,
-    mediatr: 736.1,
-  },
-  {
-    name: "Publish (3 Handlers)",
-    qorpe: 523.8,
-    mediatr: 1_073.2,
-  },
-  {
-    name: "Publish (5 Handlers)",
-    qorpe: 694.2,
-    mediatr: 2_056.7,
-  },
+  { name: "1 Handler", qorpe: 23, mediatr: 44 },
+  { name: "10 Handlers", qorpe: 69, mediatr: 185 },
+  { name: "50 Handlers", qorpe: 273, mediatr: 786 },
+  { name: "100 Handlers", qorpe: 530, mediatr: 1608 },
 ];
 
 export const memoryBenchmarks = [
-  {
-    name: "Send",
-    qorpe: 480,
-    mediatr: 600,
-  },
-  {
-    name: "Publish (1H)",
-    qorpe: 376,
-    mediatr: 1_264,
-  },
-  {
-    name: "Publish (3H)",
-    qorpe: 376,
-    mediatr: 1_776,
-  },
-  {
-    name: "Publish (5H)",
-    qorpe: 376,
-    mediatr: 2_288,
-  },
+  { name: "Send (0 beh)", qorpe: 64, mediatr: 128 },
+  { name: "Send (4 beh)", qorpe: 696, mediatr: 800 },
+  { name: "Query", qorpe: 104, mediatr: 200 },
+  { name: "Publish (1H)", qorpe: 88, mediatr: 288 },
+  { name: "Publish (10H)", qorpe: 376, mediatr: 1656 },
+  { name: "Publish (100H)", qorpe: 3256, mediatr: 15336 },
 ];

--- a/dashboard/src/data/config.ts
+++ b/dashboard/src/data/config.ts
@@ -1,0 +1,19 @@
+/**
+ * Central configuration for the dashboard.
+ * Update this single file when releasing a new version or updating benchmarks.
+ */
+
+export const APP_VERSION = "1.0.0-beta.8";
+
+export const heroStats = {
+  fasterPublish: "66%",
+  lessMemory: "4.7x",
+  pipelineBehaviors: "11",
+  testsCoverage: "252",
+};
+
+export const benchmarkHighlights = {
+  fasterPercent: "~66%",
+  lessMemoryMultiplier: "4.7x",
+  publishHotPath: "0 alloc",
+};

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -7,7 +7,7 @@
     "quickStart": "بداية سريعة"
   },
   "hero": {
-    "badge": "تم اصدار v1.0.0",
+    "badge": "تم الاصدار",
     "title": "وسيط CQRS للمؤسسات",
     "titleHighlight": "لمنصة .NET",
     "description": "بديل عالي الاداء وغني بالميزات لـ MediatR مع فصل CQRS صريح ونمط Result مدمج و11 سلوك خط انابيب موجه بالسمات.",

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -7,7 +7,7 @@
     "quickStart": "Schnellstart"
   },
   "hero": {
-    "badge": "v1.0.0 Veröffentlicht",
+    "badge": "Veröffentlicht",
     "title": "Enterprise-Grade CQRS Mediator",
     "titleHighlight": "für .NET",
     "description": "Eine hochleistungsfähige, funktionsreiche Alternative zu MediatR mit expliziter CQRS-Trennung, integriertem Result-Pattern und 11 attributgesteuerten Pipeline-Behaviors.",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -7,7 +7,7 @@
     "quickStart": "Quick Start"
   },
   "hero": {
-    "badge": "v1.0.0 Released",
+    "badge": "Released",
     "title": "Enterprise-Grade CQRS Mediator",
     "titleHighlight": "for .NET",
     "description": "A high-performance, feature-rich alternative to MediatR with explicit CQRS separation, built-in Result pattern, and 11 attribute-driven pipeline behaviors.",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -7,7 +7,7 @@
     "quickStart": "Inicio rápido"
   },
   "hero": {
-    "badge": "v1.0.0 Publicado",
+    "badge": "Publicado",
     "title": "Mediador CQRS Empresarial",
     "titleHighlight": "para .NET",
     "description": "Una alternativa de alto rendimiento y rica en funciones a MediatR con separacion CQRS explicita, patron Result integrado y 11 behaviors de pipeline dirigidos por atributos.",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -7,7 +7,7 @@
     "quickStart": "Démarrage rapide"
   },
   "hero": {
-    "badge": "v1.0.0 Publié",
+    "badge": "Publié",
     "title": "Mediateur CQRS Enterprise",
     "titleHighlight": "pour .NET",
     "description": "Une alternative haute performance et riche en fonctionnalites a MediatR avec une separation CQRS explicite, un Result pattern integre et 11 behaviors de pipeline pilotes par attributs.",

--- a/dashboard/src/i18n/locales/tr.json
+++ b/dashboard/src/i18n/locales/tr.json
@@ -7,7 +7,7 @@
     "quickStart": "Hızlı Başlangıç"
   },
   "hero": {
-    "badge": "v1.0.0 Yayınlandı",
+    "badge": "Yayınlandı",
     "title": "Enterprise CQRS Mediator",
     "titleHighlight": ".NET için",
     "description": "Açık CQRS ayrımı, yerleşik Result pattern ve 11 attribute-driven pipeline behavior ile MediatR'a yüksek performanslı, zengin özellikli bir alternatif.",


### PR DESCRIPTION
## Summary

- Create `dashboard/src/data/config.ts` as single source of truth for version, stats, and benchmark highlights
- **HeroSection**: stats and version badge now read from config
- **BenchmarksSection**: highlight cards (66%, 4.7x, 0 alloc) now read from config
- **benchmarks.ts**: updated with latest BenchmarkDotNet results (send scaling 0-32 behaviors, publish 1-100 handlers, memory)
- **i18n locales**: removed hardcoded version from badge text in all 6 languages — version now injected from config

## Before/After

**Before**: Change version → edit 6 locale files + HeroSection + BenchmarksSection
**After**: Change version → edit 1 line in `config.ts`

## Test Plan

- [x] Dashboard builds successfully (`npm run build`)
- [x] No hardcoded version strings remain in locale files

Closes #87