### PR TITLE
feat(behaviors): add post-commit task queue for fire-and-forget work after transaction commit

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/PostCommitTaskQueue.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/PostCommitTaskQueue.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using Qorpe.Mediator.Abstractions;
+
+namespace Qorpe.Mediator.Behaviors.Behaviors;
+
+/// <summary>
+/// Default scoped implementation of <see cref="IPostCommitTaskQueue"/>.
+/// Collects fire-and-forget tasks during handler execution; TransactionBehavior
+/// calls ExecuteAsync after the DB transaction has committed.
+/// Tasks execute sequentially; failures are logged but do not throw.
+/// </summary>
+public sealed class PostCommitTaskQueue : IPostCommitTaskQueue
+{
+    private readonly List<Func<CancellationToken, Task>> _tasks = [];
+    private readonly ILogger<PostCommitTaskQueue> _logger;
+
+    public PostCommitTaskQueue(ILogger<PostCommitTaskQueue> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public void Enqueue(Func<CancellationToken, Task> task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        _tasks.Add(task);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        if (_tasks.Count == 0) return;
+
+        var tasks = _tasks.ToList();
+        _tasks.Clear();
+
+        _logger.LogDebug("Executing {Count} post-commit tasks", tasks.Count);
+
+        for (var i = 0; i < tasks.Count; i++)
+        {
+            try
+            {
+                await tasks[i](cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Post-commit task {Index}/{Total} failed", i + 1, tasks.Count);
+            }
+        }
+    }
+}

--- a/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/TransactionBehavior.cs
@@ -26,17 +26,20 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
         .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
 
     private readonly IUnitOfWork? _unitOfWork;
+    private readonly IPostCommitTaskQueue? _postCommitQueue;
     private readonly ILogger<TransactionBehavior<TRequest, TResponse>> _logger;
     private readonly TransactionBehaviorOptions _options;
 
     public TransactionBehavior(
         ILogger<TransactionBehavior<TRequest, TResponse>> logger,
         IOptions<TransactionBehaviorOptions> options,
-        IUnitOfWork? unitOfWork = null)
+        IUnitOfWork? unitOfWork = null,
+        IPostCommitTaskQueue? postCommitQueue = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _unitOfWork = unitOfWork;
+        _postCommitQueue = postCommitQueue;
     }
 
     public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
@@ -86,6 +89,13 @@ public sealed class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior
         {
             await _unitOfWork.CommitAsync(cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Committed transaction for {RequestName}", requestName);
+
+            // Execute post-commit tasks after successful commit
+            if (_postCommitQueue is not null)
+            {
+                await _postCommitQueue.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
             return response;
         }
         catch (Exception ex)

--- a/src/Qorpe.Mediator.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
+++ b/src/Qorpe.Mediator.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
@@ -74,7 +74,7 @@ public static class BehaviorServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds transaction behavior.
+    /// Adds transaction behavior with optional post-commit task queue.
     /// </summary>
     public static IServiceCollection AddQorpeTransactions(
         this IServiceCollection services,
@@ -87,6 +87,7 @@ public static class BehaviorServiceCollectionExtensions
         services.AddOptionsWithValidateOnStart<TransactionBehaviorOptions>()
             .Validate(o => o.DefaultTimeoutSeconds > 0, "DefaultTimeoutSeconds must be positive.");
 
+        services.TryAddScoped<IPostCommitTaskQueue, Behaviors.PostCommitTaskQueue>();
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionBehavior<,>));
         return services;
     }

--- a/src/Qorpe.Mediator/Abstractions/IAuditStore.cs
+++ b/src/Qorpe.Mediator/Abstractions/IAuditStore.cs
@@ -94,6 +94,28 @@ public interface IUnitOfWork
 }
 
 /// <summary>
+/// Defines a queue for fire-and-forget tasks that execute after a transaction commits.
+/// Register as Scoped in DI. Handlers enqueue tasks during execution, and
+/// TransactionBehavior calls ExecuteAsync after successful commit.
+/// </summary>
+public interface IPostCommitTaskQueue
+{
+    /// <summary>
+    /// Enqueues a task to run after the transaction commits.
+    /// </summary>
+    /// <param name="task">The async task to execute post-commit.</param>
+    void Enqueue(Func<CancellationToken, Task> task);
+
+    /// <summary>
+    /// Executes all queued tasks sequentially. Failures are logged but do not throw.
+    /// Called by TransactionBehavior after successful commit.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ExecuteAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
 /// Defines the idempotency store for checking duplicate requests.
 /// </summary>
 public interface IIdempotencyStore

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/PostCommitTaskQueueTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/PostCommitTaskQueueTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Qorpe.Mediator.Abstractions;
+using Qorpe.Mediator.Behaviors.Behaviors;
+using Qorpe.Mediator.Behaviors.Configuration;
+using Qorpe.Mediator.Results;
+using Qorpe.Mediator.Behaviors.Attributes;
+using Qorpe.Mediator.DependencyInjection;
+
+namespace Qorpe.Mediator.UnitTests.Behaviors;
+
+public class PostCommitTaskQueueTests
+{
+    // --- Test types ---
+    [Transactional]
+    public sealed record PostCommitCommand(string Data) : ICommand<Result>;
+    public sealed class PostCommitCommandHandler : ICommandHandler<PostCommitCommand>
+    {
+        private readonly IPostCommitTaskQueue _queue;
+        public PostCommitCommandHandler(IPostCommitTaskQueue queue) => _queue = queue;
+
+        public ValueTask<Result> Handle(PostCommitCommand request, CancellationToken cancellationToken)
+        {
+            _queue.Enqueue(async ct => { await Task.Delay(1, ct); });
+            return new(Result.Success());
+        }
+    }
+
+    // --- PostCommitTaskQueue unit tests ---
+
+    [Fact]
+    public async Task ExecuteAsync_With_No_Tasks_Should_Complete_Immediately()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        await queue.ExecuteAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Execute_All_Enqueued_Tasks()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var executed = new List<int>();
+
+        queue.Enqueue(async _ => { executed.Add(1); await Task.CompletedTask; });
+        queue.Enqueue(async _ => { executed.Add(2); await Task.CompletedTask; });
+        queue.Enqueue(async _ => { executed.Add(3); await Task.CompletedTask; });
+
+        await queue.ExecuteAsync(CancellationToken.None);
+
+        executed.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Execute_Tasks_Sequentially()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var order = new List<int>();
+
+        queue.Enqueue(async ct => { await Task.Delay(50, ct); order.Add(1); });
+        queue.Enqueue(async ct => { await Task.Delay(10, ct); order.Add(2); });
+        queue.Enqueue(async _ => { order.Add(3); await Task.CompletedTask; });
+
+        await queue.ExecuteAsync(CancellationToken.None);
+
+        // Sequential execution means 1 finishes before 2 starts
+        order.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Clear_Queue_After_Execution()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var count = 0;
+
+        queue.Enqueue(async _ => { count++; await Task.CompletedTask; });
+        await queue.ExecuteAsync(CancellationToken.None);
+        count.Should().Be(1);
+
+        // Second execution should do nothing — queue was cleared
+        await queue.ExecuteAsync(CancellationToken.None);
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Not_Throw_On_Task_Failure()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var executed = new List<int>();
+
+        queue.Enqueue(async _ => { executed.Add(1); await Task.CompletedTask; });
+        queue.Enqueue(_ => throw new InvalidOperationException("Task 2 failed"));
+        queue.Enqueue(async _ => { executed.Add(3); await Task.CompletedTask; });
+
+        // Should not throw — failures are logged but swallowed
+        await queue.ExecuteAsync(CancellationToken.None);
+
+        // Task 1 and 3 should still execute, task 2 failed silently
+        executed.Should().Equal(1, 3);
+    }
+
+    [Fact]
+    public void Enqueue_Null_Should_Throw_ArgumentNullException()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var act = () => queue.Enqueue(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // --- TransactionBehavior integration with PostCommitTaskQueue ---
+
+    [Fact]
+    public async Task TransactionBehavior_Should_Execute_PostCommitQueue_After_Commit()
+    {
+        var taskExecuted = false;
+        var commitOccurred = false;
+        var taskExecutedAfterCommit = false;
+
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        queue.Enqueue(async _ =>
+        {
+            taskExecutedAfterCommit = commitOccurred;
+            taskExecuted = true;
+            await Task.CompletedTask;
+        });
+
+        var unitOfWork = new TestUnitOfWork(onCommit: () => commitOccurred = true);
+        var behavior = new TransactionBehavior<PostCommitCommand, Result>(
+            NullLogger<TransactionBehavior<PostCommitCommand, Result>>.Instance,
+            Options.Create(new TransactionBehaviorOptions()),
+            unitOfWork,
+            queue);
+
+        var result = await behavior.Handle(
+            new PostCommitCommand("test"),
+            () => new ValueTask<Result>(Result.Success()),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        taskExecuted.Should().BeTrue("post-commit task should have been executed");
+        taskExecutedAfterCommit.Should().BeTrue("post-commit task should run AFTER commit");
+    }
+
+    [Fact]
+    public async Task TransactionBehavior_Should_Not_Execute_PostCommitQueue_On_Rollback()
+    {
+        var taskExecuted = false;
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        queue.Enqueue(async _ => { taskExecuted = true; await Task.CompletedTask; });
+
+        var unitOfWork = new TestUnitOfWork();
+        var behavior = new TransactionBehavior<PostCommitCommand, Result>(
+            NullLogger<TransactionBehavior<PostCommitCommand, Result>>.Instance,
+            Options.Create(new TransactionBehaviorOptions()),
+            unitOfWork,
+            queue);
+
+        var act = () => behavior.Handle(
+            new PostCommitCommand("test"),
+            () => throw new InvalidOperationException("Handler failed"),
+            CancellationToken.None).AsTask();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        taskExecuted.Should().BeFalse("post-commit tasks should NOT execute on rollback");
+    }
+
+    [Fact]
+    public async Task TransactionBehavior_Without_PostCommitQueue_Should_Work_Normally()
+    {
+        var unitOfWork = new TestUnitOfWork();
+        var behavior = new TransactionBehavior<PostCommitCommand, Result>(
+            NullLogger<TransactionBehavior<PostCommitCommand, Result>>.Instance,
+            Options.Create(new TransactionBehaviorOptions()),
+            unitOfWork,
+            postCommitQueue: null);
+
+        var result = await behavior.Handle(
+            new PostCommitCommand("test"),
+            () => new ValueTask<Result>(Result.Success()),
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        unitOfWork.CommitCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PostCommitQueue_Concurrent_Enqueue_Should_Be_Safe()
+    {
+        var queue = new PostCommitTaskQueue(NullLogger<PostCommitTaskQueue>.Instance);
+        var count = 0;
+
+        // Enqueue from multiple threads
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() =>
+        {
+            queue.Enqueue(async _ => { Interlocked.Increment(ref count); await Task.CompletedTask; });
+        }));
+
+        await Task.WhenAll(tasks);
+        await queue.ExecuteAsync(CancellationToken.None);
+
+        count.Should().Be(100);
+    }
+
+    // --- Test helpers ---
+    private sealed class TestUnitOfWork : IUnitOfWork
+    {
+        private readonly Action? _onCommit;
+        public bool CommitCalled { get; private set; }
+
+        public TestUnitOfWork(Action? onCommit = null) => _onCommit = onCommit;
+
+        public ValueTask BeginTransactionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask CommitAsync(CancellationToken cancellationToken)
+        {
+            CommitCalled = true;
+            _onCommit?.Invoke();
+            return ValueTask.CompletedTask;
+        }
+        public ValueTask RollbackAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask CreateSavepointAsync(string name, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask RollbackToSavepointAsync(string name, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `IPostCommitTaskQueue` abstraction to core abstractions
- Add default `PostCommitTaskQueue` implementation (scoped, sequential execution, best-effort)
- Integrate into `TransactionBehavior` — executes queued tasks after successful commit
- Fully backward compatible — `IPostCommitTaskQueue` is optional dependency
- Auto-registered as Scoped when `AddQorpeTransactions()` is called

## Usage

```csharp
public class CreateOrderHandler(IPostCommitTaskQueue postCommit) : ICommandHandler<CreateOrderCommand>
{
    public async ValueTask<Result> Handle(CreateOrderCommand cmd, CancellationToken ct)
    {
        // ... save order to DB ...

        postCommit.Enqueue(async ct => await emailService.SendConfirmationAsync(cmd.Email, ct));

        return Result.Success();
        // Email sends AFTER transaction commits
    }
}
```

## Test Plan

- [x] 10 new unit tests (queue execution, ordering, failure isolation, null safety, concurrent enqueue, commit/rollback integration, backward compat)
- [x] All 223 unit tests pass
- [x] Build succeeds on all target frameworks

Closes #89