### PR TITLE
feat(behaviors): add IAuditableRequest interface for rich audit metadata

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/AuditBehavior.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/AuditBehavior.cs
@@ -70,6 +70,27 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
             Timestamp = DateTimeOffset.UtcNow
         };
 
+        // Enrich with IAuditableRequest metadata if implemented
+        if (request is IAuditableRequest auditableRequest)
+        {
+            entry.ActionName = auditableRequest.ActionName;
+            entry.EntityType = auditableRequest.EntityType;
+            entry.EntityId = auditableRequest.EntityId;
+
+            if (auditableRequest.AuditMetadata is not null)
+            {
+                try
+                {
+                    var metadataJson = JsonSerializer.Serialize(auditableRequest.AuditMetadata);
+                    entry.Metadata["AuditMetadata"] = metadataJson;
+                }
+                catch
+                {
+                    // Best-effort metadata serialization
+                }
+            }
+        }
+
         if (CachedAttribute?.IncludeRequestBody != false)
         {
             entry.RequestData = SafeSerializeRequest(request);
@@ -105,12 +126,17 @@ public sealed class AuditBehavior<TRequest, TResponse> : IPipelineBehavior<TRequ
         }
     }
 
+    // Cached check for IAuditableRequest implementation
+    private static readonly bool ImplementsIAuditableRequest =
+        typeof(IAuditableRequest).IsAssignableFrom(typeof(TRequest));
+
     private bool ShouldAudit()
     {
         if (IsCommandType && _options.AuditCommands) return true;
         if (IsQueryType && _options.AuditQueries) return true;
 
-        return CachedAttribute is not null;
+        // Audit if [Auditable] attribute or IAuditableRequest interface is present
+        return CachedAttribute is not null || ImplementsIAuditableRequest;
     }
 
     private string SafeSerializeRequest(TRequest request)

--- a/src/Qorpe.Mediator/Abstractions/IAuditableRequest.cs
+++ b/src/Qorpe.Mediator/Abstractions/IAuditableRequest.cs
@@ -1,0 +1,42 @@
+namespace Qorpe.Mediator.Abstractions;
+
+/// <summary>
+/// Marker interface for requests that provide structured audit metadata.
+/// Implement this on command/query records to supply ActionName, EntityType, EntityId,
+/// and custom metadata for the audit log. Works alongside [Auditable] attribute —
+/// attribute enables audit logging, this interface enriches it with domain context.
+/// </summary>
+/// <example>
+/// <code>
+/// [Auditable]
+/// public record CreateOrderCommand(string Product) : ICommand&lt;Result&gt;, IAuditableRequest
+/// {
+///     public string ActionName => "Order.Create";
+///     public string? EntityType => "Order";
+///     public string? EntityId => null; // set after creation
+///     public object? AuditMetadata => new { Product };
+/// }
+/// </code>
+/// </example>
+public interface IAuditableRequest
+{
+    /// <summary>
+    /// Gets the action name for audit logging (e.g., "Order.Create", "User.Delete").
+    /// </summary>
+    string ActionName { get; }
+
+    /// <summary>
+    /// Gets the type of entity being acted upon (e.g., "Order", "User"), or null if not applicable.
+    /// </summary>
+    string? EntityType { get; }
+
+    /// <summary>
+    /// Gets the identifier of the entity being acted upon, or null if not applicable.
+    /// </summary>
+    string? EntityId { get; }
+
+    /// <summary>
+    /// Gets optional metadata to include in the audit entry. Serialized to JSON.
+    /// </summary>
+    object? AuditMetadata { get; }
+}

--- a/src/Qorpe.Mediator/Audit/AuditEntry.cs
+++ b/src/Qorpe.Mediator/Audit/AuditEntry.cs
@@ -66,6 +66,21 @@ public sealed class AuditEntry
     public string? ExceptionType { get; set; }
 
     /// <summary>
+    /// Gets or sets the action name from IAuditableRequest (e.g., "Order.Create").
+    /// </summary>
+    public string? ActionName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the entity type from IAuditableRequest (e.g., "Order").
+    /// </summary>
+    public string? EntityType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the entity identifier from IAuditableRequest (e.g., "12345").
+    /// </summary>
+    public string? EntityId { get; set; }
+
+    /// <summary>
     /// Gets or sets additional metadata about the request.
     /// </summary>
     public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
@@ -87,6 +102,9 @@ public sealed class AuditEntry
         IsSuccess = false;
         ErrorMessage = null;
         ExceptionType = null;
+        ActionName = null;
+        EntityType = null;
+        EntityId = null;
         Metadata.Clear();
     }
 }

--- a/tests/Qorpe.Mediator.UnitTests/Behaviors/AuditBehaviorTests.cs
+++ b/tests/Qorpe.Mediator.UnitTests/Behaviors/AuditBehaviorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Qorpe.Mediator.Abstractions;
 using Qorpe.Mediator.Audit;
+using Qorpe.Mediator.Behaviors.Attributes;
 using Qorpe.Mediator.Behaviors.Behaviors;
 using Qorpe.Mediator.Behaviors.Configuration;
 using Qorpe.Mediator.Results;
@@ -155,5 +156,104 @@ public class AuditBehaviorTests
         await behavior.Handle(new TransactionalCommand("data"), next, CancellationToken.None);
 
         _store.GetAll()[0].CorrelationId.Should().NotBeNullOrEmpty();
+    }
+
+    // --- IAuditableRequest metadata tests ---
+
+    [Auditable]
+    public sealed record AuditableMetadataCommand(string OrderId) : ICommand<Result>, IAuditableRequest
+    {
+        public string ActionName => "Order.Create";
+        public string? EntityType => "Order";
+        public string? EntityId => OrderId;
+        public object? AuditMetadata => new { Source = "API", Priority = "High" };
+    }
+
+    public sealed record AuditableWithoutAttributeCommand(string Data) : ICommand<Result>, IAuditableRequest
+    {
+        public string ActionName => "Data.Process";
+        public string? EntityType => null;
+        public string? EntityId => null;
+        public object? AuditMetadata => null;
+    }
+
+    [Fact]
+    public async Task Should_Populate_ActionName_EntityType_EntityId_From_IAuditableRequest()
+    {
+        var logger = Substitute.For<ILogger<AuditBehavior<AuditableMetadataCommand, Result>>>();
+        var opts = new AuditBehaviorOptions { AuditCommands = true };
+        var behavior = new AuditBehavior<AuditableMetadataCommand, Result>(
+            _store, logger, Options.Create(opts));
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new AuditableMetadataCommand("ORD-123"), next, CancellationToken.None);
+
+        var entries = _store.GetAll();
+        entries.Should().ContainSingle();
+        var entry = entries[0];
+        entry.ActionName.Should().Be("Order.Create");
+        entry.EntityType.Should().Be("Order");
+        entry.EntityId.Should().Be("ORD-123");
+        entry.Metadata.Should().ContainKey("AuditMetadata");
+        entry.Metadata["AuditMetadata"].Should().Contain("API");
+        entry.Metadata["AuditMetadata"].Should().Contain("High");
+    }
+
+    [Fact]
+    public async Task Should_Audit_IAuditableRequest_Without_Auditable_Attribute()
+    {
+        var logger = Substitute.For<ILogger<AuditBehavior<AuditableWithoutAttributeCommand, Result>>>();
+        var opts = new AuditBehaviorOptions { AuditCommands = false, AuditQueries = false };
+        var behavior = new AuditBehavior<AuditableWithoutAttributeCommand, Result>(
+            _store, logger, Options.Create(opts));
+
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new AuditableWithoutAttributeCommand("test"), next, CancellationToken.None);
+
+        var entries = _store.GetAll();
+        entries.Should().ContainSingle();
+        entries[0].ActionName.Should().Be("Data.Process");
+        entries[0].EntityType.Should().BeNull();
+        entries[0].EntityId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Should_Not_Populate_Metadata_Fields_Without_IAuditableRequest()
+    {
+        var behavior = CreateBehavior();
+        RequestHandlerDelegate<Result> next = () => new ValueTask<Result>(Result.Success());
+
+        await behavior.Handle(new TransactionalCommand("data"), next, CancellationToken.None);
+
+        var entry = _store.GetAll()[0];
+        entry.ActionName.Should().BeNull();
+        entry.EntityType.Should().BeNull();
+        entry.EntityId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Should_Capture_Metadata_On_Failure_With_IAuditableRequest()
+    {
+        var logger = Substitute.For<ILogger<AuditBehavior<AuditableMetadataCommand, Result>>>();
+        var opts = new AuditBehaviorOptions { AuditCommands = true };
+        var behavior = new AuditBehavior<AuditableMetadataCommand, Result>(
+            _store, logger, Options.Create(opts));
+
+        RequestHandlerDelegate<Result> next = () => throw new InvalidOperationException("fail");
+
+        var act = () => behavior.Handle(
+            new AuditableMetadataCommand("ORD-456"), next, CancellationToken.None).AsTask();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        var entries = _store.GetAll();
+        entries.Should().ContainSingle();
+        var entry = entries[0];
+        entry.IsSuccess.Should().BeFalse();
+        entry.ActionName.Should().Be("Order.Create");
+        entry.EntityId.Should().Be("ORD-456");
+        entry.ErrorMessage.Should().Contain("fail");
     }
 }


### PR DESCRIPTION
## Summary

- Add `IAuditableRequest` interface to core abstractions (ActionName, EntityType, EntityId, AuditMetadata)
- Extend `AuditEntry` with ActionName, EntityType, EntityId fields
- `AuditBehavior` detects `IAuditableRequest` and enriches audit entries with domain context
- Implementing `IAuditableRequest` alone triggers audit logging (no `[Auditable]` attribute needed)
- Fully backward compatible — existing `[Auditable]` usage unchanged

## Usage

```csharp
[Auditable]
public record CreateOrderCommand(string Product) : ICommand<Result>, IAuditableRequest
{
    public string ActionName => "Order.Create";
    public string? EntityType => "Order";
    public string? EntityId => null;
    public object? AuditMetadata => new { Product };
}
```

## Test Plan

- [x] 4 new unit tests (metadata population, audit-without-attribute, backward compat, failure capture)
- [x] All 256 tests pass (217 unit + 21 integration + 18 load)

Closes #91