### PR TITLE
fix(behaviors): make PostCommitTaskQueue thread-safe

### DIFF
--- a/src/Qorpe.Mediator.Behaviors/Behaviors/PostCommitTaskQueue.cs
+++ b/src/Qorpe.Mediator.Behaviors/Behaviors/PostCommitTaskQueue.cs
@@ -11,6 +11,7 @@ namespace Qorpe.Mediator.Behaviors.Behaviors;
 /// </summary>
 public sealed class PostCommitTaskQueue : IPostCommitTaskQueue
 {
+    private readonly object _lock = new();
     private readonly List<Func<CancellationToken, Task>> _tasks = [];
     private readonly ILogger<PostCommitTaskQueue> _logger;
 
@@ -23,16 +24,19 @@ public sealed class PostCommitTaskQueue : IPostCommitTaskQueue
     public void Enqueue(Func<CancellationToken, Task> task)
     {
         ArgumentNullException.ThrowIfNull(task);
-        _tasks.Add(task);
+        lock (_lock) { _tasks.Add(task); }
     }
 
     /// <inheritdoc />
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        if (_tasks.Count == 0) return;
-
-        var tasks = _tasks.ToList();
-        _tasks.Clear();
+        List<Func<CancellationToken, Task>> tasks;
+        lock (_lock)
+        {
+            if (_tasks.Count == 0) return;
+            tasks = _tasks.ToList();
+            _tasks.Clear();
+        }
 
         _logger.LogDebug("Executing {Count} post-commit tasks", tasks.Count);
 


### PR DESCRIPTION
## Problem

CI failed on `PostCommitQueue_Concurrent_Enqueue_Should_Be_Safe` — `List<T>.Add` is not thread-safe and concurrent enqueue causes data loss.

## Fix

Add `object` lock around `Enqueue` and `ExecuteAsync`. Uses `object` instead of `Lock` for net8.0 compatibility.

## Test Plan

- [x] All 227 unit tests pass (including concurrent enqueue test)
- [x] Build succeeds on net8.0, net9.0, net10.0