### PR TITLE
chore: finalize omercelikdev/mediant (Trusted Publishing + URLs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write   # required for NuGet.org Trusted Publishing (OIDC)
 
 jobs:
   release:
@@ -79,17 +80,25 @@ jobs:
             -p:Version=${{ steps.version.outputs.VERSION }} \
             --output ./nupkgs
 
+      # Trusted Publishing: exchanges the workflow's OIDC token for a short-lived NuGet.org
+      # API key (no long-lived secret). Requires a matching trusted-publishing policy on nuget.org.
+      - name: NuGet login (Trusted Publishing / OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: omercelikdev
+
       - name: Push to NuGet.org
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
 
       - name: Push Symbol Packages
         run: |
           dotnet nuget push ./nupkgs/*.snupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
         continue-on-error: true
@@ -98,7 +107,7 @@ jobs:
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
-            --source https://nuget.pkg.github.com/qorpe/index.json \
+            --source https://nuget.pkg.github.com/omercelikdev/index.json \
             --skip-duplicate
         continue-on-error: true
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,14 +16,14 @@
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/qorpe/mediator</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/qorpe/mediator</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/omercelikdev/mediant</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/omercelikdev/mediant</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>cqrs;mediator;mediatr-alternative;pipeline;command;query;dotnet;clean-architecture;ddd;domain-events;result-pattern</PackageTags>
     <Description>Enterprise-grade CQRS mediator for .NET — Result pattern, pipeline behaviors, DDD-ready. Free forever.</Description>
     <Copyright>Copyright (c) omercelikdev 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>https://github.com/qorpe/mediator/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/omercelikdev/mediant/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- Documentation -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NuGet](https://img.shields.io/nuget/vpre/Mediant.svg)](https://www.nuget.org/packages/Mediant/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Mediant.svg)](https://www.nuget.org/packages/Mediant/)
-[![Build](https://github.com/qorpe/mediator/actions/workflows/ci.yml/badge.svg)](https://github.com/qorpe/mediator/actions/workflows/ci.yml)
+[![Build](https://github.com/omercelikdev/mediant/actions/workflows/ci.yml/badge.svg)](https://github.com/omercelikdev/mediant/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-blue)](https://dotnet.microsoft.com/)
 

--- a/dashboard/src/components/layout/Footer.tsx
+++ b/dashboard/src/components/layout/Footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
               {t("footer.description")}
             </p>
             <a
-              href="https://github.com/qorpe/mediator"
+              href="https://github.com/omercelikdev/mediant"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 mt-4 text-sm text-text-secondary hover:text-text-primary transition-colors"
@@ -45,9 +45,9 @@ export function Footer() {
             </h4>
             <ul className="space-y-3">
               {[
-                { label: t("footer.documentation"), href: "https://github.com/qorpe/mediator/blob/main/docs/README.md" },
-                { label: t("footer.migrationGuide"), href: "https://github.com/qorpe/mediator/blob/main/docs/MIGRATION_GUIDE.md" },
-                { label: t("footer.changelog"), href: "https://github.com/qorpe/mediator/blob/main/docs/CHANGELOG.md" },
+                { label: t("footer.documentation"), href: "https://github.com/omercelikdev/mediant/blob/main/docs/README.md" },
+                { label: t("footer.migrationGuide"), href: "https://github.com/omercelikdev/mediant/blob/main/docs/MIGRATION_GUIDE.md" },
+                { label: t("footer.changelog"), href: "https://github.com/omercelikdev/mediant/blob/main/docs/CHANGELOG.md" },
               ].map((link) => (
                 <li key={link.label}>
                   <a
@@ -70,9 +70,9 @@ export function Footer() {
             </h4>
             <ul className="space-y-3">
               {[
-                { label: t("footer.github"), href: "https://github.com/qorpe/mediator" },
-                { label: t("footer.issues"), href: "https://github.com/qorpe/mediator/issues" },
-                { label: t("footer.discussions"), href: "https://github.com/qorpe/mediator/discussions" },
+                { label: t("footer.github"), href: "https://github.com/omercelikdev/mediant" },
+                { label: t("footer.issues"), href: "https://github.com/omercelikdev/mediant/issues" },
+                { label: t("footer.discussions"), href: "https://github.com/omercelikdev/mediant/discussions" },
                 { label: t("footer.nuget"), href: "https://www.nuget.org/packages/Mediant" },
               ].map((link) => (
                 <li key={link.label}>
@@ -97,7 +97,7 @@ export function Footer() {
             <ul className="space-y-3">
               <li>
                 <a
-                  href="https://github.com/qorpe/mediator/blob/main/LICENSE"
+                  href="https://github.com/omercelikdev/mediant/blob/main/LICENSE"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-text-secondary hover:text-text-primary transition-colors"

--- a/dashboard/src/components/sections/BenchmarksSection.tsx
+++ b/dashboard/src/components/sections/BenchmarksSection.tsx
@@ -30,7 +30,7 @@ const dataMap: Record<Tab, typeof sendBenchmarks> = {
   memory: memoryBenchmarks,
 };
 
-const QORPE_COLOR = "#3b82f6";
+const MEDIANT_COLOR = "#3b82f6";
 const MEDIATR_COLOR = "#94a3b8";
 
 interface TooltipPayloadItem {
@@ -139,13 +139,13 @@ export function BenchmarksSection() {
                   cursor={{ fill: "var(--color-surface-hover)", radius: 8 }}
                 />
                 <Bar
-                  dataKey="qorpe"
-                  name={t("benchmarks.qorpe")}
+                  dataKey="mediant"
+                  name={t("benchmarks.mediant")}
                   radius={[8, 8, 0, 0]}
                   maxBarSize={60}
                 >
                   {data.map((_, index) => (
-                    <Cell key={`q-${index}`} fill={QORPE_COLOR} />
+                    <Cell key={`q-${index}`} fill={MEDIANT_COLOR} />
                   ))}
                 </Bar>
                 <Bar
@@ -164,7 +164,7 @@ export function BenchmarksSection() {
             {/* Legend */}
             <div className="flex justify-center gap-8 mt-6 pt-6 border-t border-border">
               <div className="flex items-center gap-2">
-                <span className="w-3 h-3 rounded-full" style={{ backgroundColor: QORPE_COLOR }} />
+                <span className="w-3 h-3 rounded-full" style={{ backgroundColor: MEDIANT_COLOR }} />
                 <span className="text-sm font-medium text-text-primary">Mediant Mediator</span>
               </div>
               <div className="flex items-center gap-2">

--- a/dashboard/src/components/sections/ComparisonSection.tsx
+++ b/dashboard/src/components/sections/ComparisonSection.tsx
@@ -66,7 +66,7 @@ export function ComparisonSection() {
                 {t("comparison.feature")}
               </div>
               <div className="px-6 py-4 text-sm font-semibold text-brand-600 dark:text-brand-400 text-center">
-                {t("comparison.qorpe")}
+                {t("comparison.mediant")}
               </div>
               <div className="px-6 py-4 text-sm font-semibold text-text-secondary text-center">
                 {t("comparison.mediatr")}
@@ -86,7 +86,7 @@ export function ComparisonSection() {
                   {t(`comparison.items.${row.key}`)}
                 </div>
                 <div className="px-6 py-4 text-center">
-                  <ValueCell value={row.qorpe} highlight={row.qorpeHighlight} />
+                  <ValueCell value={row.mediant} highlight={row.mediantHighlight} />
                 </div>
                 <div className="px-6 py-4 text-center">
                   <ValueCell value={row.mediatr} highlight={false} />

--- a/dashboard/src/components/sections/HeroSection.tsx
+++ b/dashboard/src/components/sections/HeroSection.tsx
@@ -72,7 +72,7 @@ export function HeroSection() {
                 size="lg"
                 className="w-full sm:w-auto"
                 onClick={() =>
-                  window.open("https://github.com/qorpe/mediator", "_blank")
+                  window.open("https://github.com/omercelikdev/mediant", "_blank")
                 }
               >
                 <GithubIcon className="w-4 h-4" />

--- a/dashboard/src/data/benchmarks.ts
+++ b/dashboard/src/data/benchmarks.ts
@@ -5,27 +5,27 @@
  */
 
 export const sendBenchmarks = [
-  { name: "0 Behaviors", qorpe: 25, mediatr: 24 },
-  { name: "1 Behavior", qorpe: 64, mediatr: 58 },
-  { name: "2 Behaviors", qorpe: 74, mediatr: 74 },
-  { name: "4 Behaviors", qorpe: 102, mediatr: 104 },
-  { name: "8 Behaviors", qorpe: 160, mediatr: 164 },
-  { name: "16 Behaviors", qorpe: 270, mediatr: 280 },
-  { name: "32 Behaviors", qorpe: 490, mediatr: 516 },
+  { name: "0 Behaviors", mediant: 25, mediatr: 24 },
+  { name: "1 Behavior", mediant: 64, mediatr: 58 },
+  { name: "2 Behaviors", mediant: 74, mediatr: 74 },
+  { name: "4 Behaviors", mediant: 102, mediatr: 104 },
+  { name: "8 Behaviors", mediant: 160, mediatr: 164 },
+  { name: "16 Behaviors", mediant: 270, mediatr: 280 },
+  { name: "32 Behaviors", mediant: 490, mediatr: 516 },
 ];
 
 export const publishBenchmarks = [
-  { name: "1 Handler", qorpe: 23, mediatr: 44 },
-  { name: "10 Handlers", qorpe: 69, mediatr: 185 },
-  { name: "50 Handlers", qorpe: 273, mediatr: 786 },
-  { name: "100 Handlers", qorpe: 530, mediatr: 1608 },
+  { name: "1 Handler", mediant: 23, mediatr: 44 },
+  { name: "10 Handlers", mediant: 69, mediatr: 185 },
+  { name: "50 Handlers", mediant: 273, mediatr: 786 },
+  { name: "100 Handlers", mediant: 530, mediatr: 1608 },
 ];
 
 export const memoryBenchmarks = [
-  { name: "Send (0 beh)", qorpe: 64, mediatr: 128 },
-  { name: "Send (4 beh)", qorpe: 696, mediatr: 800 },
-  { name: "Query", qorpe: 104, mediatr: 200 },
-  { name: "Publish (1H)", qorpe: 88, mediatr: 288 },
-  { name: "Publish (10H)", qorpe: 376, mediatr: 1656 },
-  { name: "Publish (100H)", qorpe: 3256, mediatr: 15336 },
+  { name: "Send (0 beh)", mediant: 64, mediatr: 128 },
+  { name: "Send (4 beh)", mediant: 696, mediatr: 800 },
+  { name: "Query", mediant: 104, mediatr: 200 },
+  { name: "Publish (1H)", mediant: 88, mediatr: 288 },
+  { name: "Publish (10H)", mediant: 376, mediatr: 1656 },
+  { name: "Publish (100H)", mediant: 3256, mediatr: 15336 },
 ];

--- a/dashboard/src/data/comparison.ts
+++ b/dashboard/src/data/comparison.ts
@@ -2,64 +2,64 @@ export type ComparisonValue = "yes" | "no" | "partial" | string;
 
 export interface ComparisonRow {
   key: string;
-  qorpe: ComparisonValue;
+  mediant: ComparisonValue;
   mediatr: ComparisonValue;
-  qorpeHighlight: boolean;
+  mediantHighlight: boolean;
 }
 
 export const comparisonData: ComparisonRow[] = [
   {
     key: "license",
-    qorpe: "mitLicense",
+    mediant: "mitLicense",
     mediatr: "apacheLicense",
-    qorpeHighlight: false,
+    mediantHighlight: false,
   },
   {
     key: "cqrsTypes",
-    qorpe: "yes",
+    mediant: "yes",
     mediatr: "no",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "resultPattern",
-    qorpe: "yes",
+    mediant: "yes",
     mediatr: "no",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "pipelineBehaviors",
-    qorpe: "eleven",
+    mediant: "eleven",
     mediatr: "custom",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "httpEndpoints",
-    qorpe: "yes",
+    mediant: "yes",
     mediatr: "no",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "streaming",
-    qorpe: "yes",
+    mediant: "yes",
     mediatr: "partial",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "performance",
-    qorpe: "faster",
+    mediant: "faster",
     mediatr: "baseline",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "domainEvents",
-    qorpe: "builtIn",
+    mediant: "builtIn",
     mediatr: "notification",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
   {
     key: "fluentValidation",
-    qorpe: "native",
+    mediant: "native",
     mediatr: "thirdParty",
-    qorpeHighlight: true,
+    mediantHighlight: true,
   },
 ];

--- a/dashboard/src/i18n/locales/ar.json
+++ b/dashboard/src/i18n/locales/ar.json
@@ -57,7 +57,7 @@
     "memoryUsage": "استخدام الذاكرة",
     "mean": "المتوسط",
     "allocated": "المخصص",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "اسرع",
     "lessMemory": "ذاكرة اقل"
@@ -116,7 +116,7 @@
     "title": "لماذا Mediant Mediator؟",
     "subtitle": "مقارنة مفصلة مع MediatR لمساعدتك في اتخاذ قرار مستنير.",
     "feature": "الميزة",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "الرخصة",

--- a/dashboard/src/i18n/locales/de.json
+++ b/dashboard/src/i18n/locales/de.json
@@ -57,7 +57,7 @@
     "memoryUsage": "Speicherverbrauch",
     "mean": "Mittelwert",
     "allocated": "Zugewiesen",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "schneller",
     "lessMemory": "weniger Speicher"
@@ -116,7 +116,7 @@
     "title": "Warum Mediant Mediator?",
     "subtitle": "Ein detaillierter Vergleich mit MediatR, um eine fundierte Entscheidung zu treffen.",
     "feature": "Funktion",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "Lizenz",

--- a/dashboard/src/i18n/locales/en.json
+++ b/dashboard/src/i18n/locales/en.json
@@ -57,7 +57,7 @@
     "memoryUsage": "Memory Usage",
     "mean": "Mean",
     "allocated": "Allocated",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "faster",
     "lessMemory": "less memory"
@@ -116,7 +116,7 @@
     "title": "Why Mediant Mediator?",
     "subtitle": "A detailed comparison with MediatR to help you make an informed decision.",
     "feature": "Feature",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "License",

--- a/dashboard/src/i18n/locales/es.json
+++ b/dashboard/src/i18n/locales/es.json
@@ -57,7 +57,7 @@
     "memoryUsage": "Uso de memoria",
     "mean": "Media",
     "allocated": "Asignado",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "mas rápido",
     "lessMemory": "menos memoria"
@@ -116,7 +116,7 @@
     "title": "Por que Mediant Mediator?",
     "subtitle": "Una comparacion detallada con MediatR para ayudarte a tomar una decision informada.",
     "feature": "Característica",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "Licencia",

--- a/dashboard/src/i18n/locales/fr.json
+++ b/dashboard/src/i18n/locales/fr.json
@@ -57,7 +57,7 @@
     "memoryUsage": "Utilisation mémoire",
     "mean": "Moyenne",
     "allocated": "Alloue",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "plus rapide",
     "lessMemory": "moins de mémoire"
@@ -116,7 +116,7 @@
     "title": "Pourquoi Mediant Mediator?",
     "subtitle": "Une comparaison détaillée avec MediatR pour vous aider a prendre une decision éclairée.",
     "feature": "Fonctionnalite",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "Licence",

--- a/dashboard/src/i18n/locales/tr.json
+++ b/dashboard/src/i18n/locales/tr.json
@@ -57,7 +57,7 @@
     "memoryUsage": "Bellek Kullanımı",
     "mean": "Ortalama",
     "allocated": "Ayrılan",
-    "qorpe": "Mediant",
+    "mediant": "Mediant",
     "mediatr": "MediatR",
     "faster": "daha hızlı",
     "lessMemory": "daha az bellek"
@@ -116,7 +116,7 @@
     "title": "Neden Mediant Mediator?",
     "subtitle": "Bilinçli bir karar vermenize yardımcı olmak için MediatR ile ayrıntılı karşılaştırma.",
     "feature": "Özellik",
-    "qorpe": "Mediant Mediator",
+    "mediant": "Mediant Mediator",
     "mediatr": "MediatR v12",
     "items": {
       "license": "Lisans",

--- a/tests/Mediant.Benchmarks/Benchmarks.cs
+++ b/tests/Mediant.Benchmarks/Benchmarks.cs
@@ -6,7 +6,7 @@ using Mediant.DependencyInjection;
 
 namespace Mediant.Benchmarks;
 
-// ===== QORPE TYPES =====
+// ===== MEDIANT TYPES =====
 // Separate command types for 0-behavior vs N-behavior benchmarks to ensure
 // independent static generic fields (pipeline probe cache per type)
 public sealed class MediantPingCommand : MediantAbstractions.ICommand<MediantResults.Result> { }
@@ -72,16 +72,16 @@ public sealed class MediatRPassthroughBehavior<TRequest, TResponse> : global::Me
 public class MediatorBenchmarks
 {
     // Send — 0-behavior (uses MediantPingCommand for independent static cache)
-    private MediantAbstractions.IMediator _qorpe0 = null!;
+    private MediantAbstractions.IMediator _mediant0 = null!;
     private global::MediatR.IMediator _mediatR0 = null!;
 
     // Send — behavior scaling (uses MediantBehaviorCommand): 1, 2, 4, 8, 16, 32
-    private MediantAbstractions.IMediator _qorpe1B = null!;
-    private MediantAbstractions.IMediator _qorpe2B = null!;
-    private MediantAbstractions.IMediator _qorpe4B = null!;
-    private MediantAbstractions.IMediator _qorpe8B = null!;
-    private MediantAbstractions.IMediator _qorpe16B = null!;
-    private MediantAbstractions.IMediator _qorpe32B = null!;
+    private MediantAbstractions.IMediator _mediant1B = null!;
+    private MediantAbstractions.IMediator _mediant2B = null!;
+    private MediantAbstractions.IMediator _mediant4B = null!;
+    private MediantAbstractions.IMediator _mediant8B = null!;
+    private MediantAbstractions.IMediator _mediant16B = null!;
+    private MediantAbstractions.IMediator _mediant32B = null!;
     private global::MediatR.IMediator _mediatR1B = null!;
     private global::MediatR.IMediator _mediatR2B = null!;
     private global::MediatR.IMediator _mediatR4B = null!;
@@ -90,10 +90,10 @@ public class MediatorBenchmarks
     private global::MediatR.IMediator _mediatR32B = null!;
 
     // Publish — notification handler scaling: 1, 10, 50, 100
-    private MediantAbstractions.IMediator _qorpeN1 = null!;
-    private MediantAbstractions.IMediator _qorpeN10 = null!;
-    private MediantAbstractions.IMediator _qorpeN50 = null!;
-    private MediantAbstractions.IMediator _qorpeN100 = null!;
+    private MediantAbstractions.IMediator _mediantN1 = null!;
+    private MediantAbstractions.IMediator _mediantN10 = null!;
+    private MediantAbstractions.IMediator _mediantN50 = null!;
+    private MediantAbstractions.IMediator _mediantN100 = null!;
     private global::MediatR.IMediator _mediatRN1 = null!;
     private global::MediatR.IMediator _mediatRN10 = null!;
     private global::MediatR.IMediator _mediatRN50 = null!;
@@ -112,17 +112,17 @@ public class MediatorBenchmarks
     {
         var asm = typeof(MediatorBenchmarks).Assembly;
 
-        _qorpe0 = BuildMediant(asm, 0, 0);
-        _qorpe1B = BuildMediant(asm, 1, 0);
-        _qorpe2B = BuildMediant(asm, 2, 0);
-        _qorpe4B = BuildMediant(asm, 4, 0);
-        _qorpe8B = BuildMediant(asm, 8, 0);
-        _qorpe16B = BuildMediant(asm, 16, 0);
-        _qorpe32B = BuildMediant(asm, 32, 0);
-        _qorpeN1 = BuildMediant(asm, 0, 1);
-        _qorpeN10 = BuildMediant(asm, 0, 10);
-        _qorpeN50 = BuildMediant(asm, 0, 50);
-        _qorpeN100 = BuildMediant(asm, 0, 100);
+        _mediant0 = BuildMediant(asm, 0, 0);
+        _mediant1B = BuildMediant(asm, 1, 0);
+        _mediant2B = BuildMediant(asm, 2, 0);
+        _mediant4B = BuildMediant(asm, 4, 0);
+        _mediant8B = BuildMediant(asm, 8, 0);
+        _mediant16B = BuildMediant(asm, 16, 0);
+        _mediant32B = BuildMediant(asm, 32, 0);
+        _mediantN1 = BuildMediant(asm, 0, 1);
+        _mediantN10 = BuildMediant(asm, 0, 10);
+        _mediantN50 = BuildMediant(asm, 0, 50);
+        _mediantN100 = BuildMediant(asm, 0, 100);
 
         _mediatR0 = BuildMediatR(asm, 0, 0);
         _mediatR1B = BuildMediatR(asm, 1, 0);
@@ -137,17 +137,17 @@ public class MediatorBenchmarks
         _mediatRN100 = BuildMediatR(asm, 0, 100);
 
         // Warmup — behavior benchmarks use MediantBehaviorCommand (separate generic static fields)
-        _qorpe0.Send(_qCmd).AsTask().Wait();
-        _qorpe1B.Send(_qBehCmd).AsTask().Wait();
-        _qorpe2B.Send(_qBehCmd).AsTask().Wait();
-        _qorpe4B.Send(_qBehCmd).AsTask().Wait();
-        _qorpe8B.Send(_qBehCmd).AsTask().Wait();
-        _qorpe16B.Send(_qBehCmd).AsTask().Wait();
-        _qorpe32B.Send(_qBehCmd).AsTask().Wait();
-        _qorpeN1.Publish(_qNotif).AsTask().Wait();
-        _qorpeN10.Publish(_qNotif).AsTask().Wait();
-        _qorpeN50.Publish(_qNotif).AsTask().Wait();
-        _qorpeN100.Publish(_qNotif).AsTask().Wait();
+        _mediant0.Send(_qCmd).AsTask().Wait();
+        _mediant1B.Send(_qBehCmd).AsTask().Wait();
+        _mediant2B.Send(_qBehCmd).AsTask().Wait();
+        _mediant4B.Send(_qBehCmd).AsTask().Wait();
+        _mediant8B.Send(_qBehCmd).AsTask().Wait();
+        _mediant16B.Send(_qBehCmd).AsTask().Wait();
+        _mediant32B.Send(_qBehCmd).AsTask().Wait();
+        _mediantN1.Publish(_qNotif).AsTask().Wait();
+        _mediantN10.Publish(_qNotif).AsTask().Wait();
+        _mediantN50.Publish(_qNotif).AsTask().Wait();
+        _mediantN100.Publish(_qNotif).AsTask().Wait();
         _mediatR0.Send(_mCmd).Wait();
         _mediatR1B.Send(_mCmd).Wait();
         _mediatR2B.Send(_mCmd).Wait();
@@ -185,64 +185,64 @@ public class MediatorBenchmarks
 
     // ===== SEND (behavior scaling: 0, 1, 2, 4, 8, 16, 32) =====
     [Benchmark(Description = "Mediant Send (0 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_0() => _qorpe0.Send(_qCmd);
+    public ValueTask<MediantResults.Result> Q_Send_0() => _mediant0.Send(_qCmd);
     [Benchmark(Description = "MediatR Send (0 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_0() => _mediatR0.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (1 behavior)")]
-    public ValueTask<MediantResults.Result> Q_Send_1() => _qorpe1B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_1() => _mediant1B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (1 behavior)")]
     public Task<global::MediatR.Unit> M_Send_1() => _mediatR1B.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (2 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_2() => _qorpe2B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_2() => _mediant2B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (2 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_2() => _mediatR2B.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (4 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_4() => _qorpe4B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_4() => _mediant4B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (4 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_4() => _mediatR4B.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (8 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_8() => _qorpe8B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_8() => _mediant8B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (8 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_8() => _mediatR8B.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (16 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_16() => _qorpe16B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_16() => _mediant16B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (16 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_16() => _mediatR16B.Send(_mCmd);
 
     [Benchmark(Description = "Mediant Send (32 behaviors)")]
-    public ValueTask<MediantResults.Result> Q_Send_32() => _qorpe32B.Send(_qBehCmd);
+    public ValueTask<MediantResults.Result> Q_Send_32() => _mediant32B.Send(_qBehCmd);
     [Benchmark(Description = "MediatR Send (32 behaviors)")]
     public Task<global::MediatR.Unit> M_Send_32() => _mediatR32B.Send(_mCmd);
 
     // ===== QUERY =====
     [Benchmark(Description = "Mediant Query (Result<int>)")]
-    public ValueTask<MediantResults.Result<int>> Q_Query() => _qorpe0.Send(_qQuery);
+    public ValueTask<MediantResults.Result<int>> Q_Query() => _mediant0.Send(_qQuery);
     [Benchmark(Description = "MediatR Query (int)")]
     public Task<int> M_Query() => _mediatR0.Send(_mQuery);
 
     // ===== PUBLISH (handler scaling: 1, 10, 50, 100) =====
     [Benchmark(Description = "Mediant Publish (1 handler)")]
-    public ValueTask Q_Pub_1() => _qorpeN1.Publish(_qNotif);
+    public ValueTask Q_Pub_1() => _mediantN1.Publish(_qNotif);
     [Benchmark(Description = "MediatR Publish (1 handler)")]
     public Task M_Pub_1() => _mediatRN1.Publish(_mNotif);
 
     [Benchmark(Description = "Mediant Publish (10 handlers)")]
-    public ValueTask Q_Pub_10() => _qorpeN10.Publish(_qNotif);
+    public ValueTask Q_Pub_10() => _mediantN10.Publish(_qNotif);
     [Benchmark(Description = "MediatR Publish (10 handlers)")]
     public Task M_Pub_10() => _mediatRN10.Publish(_mNotif);
 
     [Benchmark(Description = "Mediant Publish (50 handlers)")]
-    public ValueTask Q_Pub_50() => _qorpeN50.Publish(_qNotif);
+    public ValueTask Q_Pub_50() => _mediantN50.Publish(_qNotif);
     [Benchmark(Description = "MediatR Publish (50 handlers)")]
     public Task M_Pub_50() => _mediatRN50.Publish(_mNotif);
 
     [Benchmark(Description = "Mediant Publish (100 handlers)")]
-    public ValueTask Q_Pub_100() => _qorpeN100.Publish(_qNotif);
+    public ValueTask Q_Pub_100() => _mediantN100.Publish(_qNotif);
     [Benchmark(Description = "MediatR Publish (100 handlers)")]
     public Task M_Pub_100() => _mediatRN100.Publish(_mNotif);
 }


### PR DESCRIPTION
Wires up the moved repo: release workflow uses NuGet Trusted Publishing (OIDC, no stored secret) and the omercelikdev package source, all URLs point to github.com/omercelikdev/mediant, and the last qorpe references (dashboard branding, benchmark fields) are renamed to mediant. 278 unit tests pass, 0 warnings.