### PR TITLE
fix(pack): analyzer & source-generator packages pack under --no-build

### DIFF
--- a/src/Mediant.Analyzers/Mediant.Analyzers.csproj
+++ b/src/Mediant.Analyzers/Mediant.Analyzers.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
@@ -23,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Mediant.SourceGenerator/Mediant.SourceGenerator.csproj
+++ b/src/Mediant.SourceGenerator/Mediant.SourceGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
@@ -18,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Release workflow packs with `dotnet pack --no-build`, which failed with **NU5017 (no dependencies nor content)** on `Mediant.Analyzers` and `Mediant.SourceGenerator`, blocking the first publish.

## Cause
- The analyzer dll was included via `$(OutputPath)\$(AssemblyName).dll` — the backslash path did not resolve reliably on Linux with `--no-build`, so the package ended up empty.
- With `IncludeBuildOutput=false` these projects have no `lib/` content, so the generated symbol `.snupkg` was empty and tripped NU5017.

## Fix
- Use `$(TargetPath)` (absolute output path) for the packed analyzer dll.
- Set `IncludeSymbols=false` for both projects (analyzers ship no symbols).

## Verification
Replicated CI locally — full `Release` build + `dotnet pack --no-build` for all 8 packages. All pack cleanly; the analyzer/generator dll lands in `analyzers/dotnet/cs/`, and only the 6 library packages emit `.snupkg`.