### PR TITLE
chore: add SECURITY.md, CONTRIBUTING.md, and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Mediant
+
+Thanks for your interest in contributing! This document explains how to build,
+test, and submit changes.
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) (the solution multi-targets
+  .NET 8/9/10; the newest SDK builds all targets)
+
+## Building and Testing
+
+```bash
+dotnet build --configuration Release
+dotnet test  --configuration Release
+```
+
+The whole suite (unit, integration, EF Core, analyzer, source generator, and load
+tests) must pass. CI additionally runs the matrix on .NET 8, 9, and 10 plus a
+Native AOT publish of `tests/Mediant.AotSample` — reflection- or trim-unsafe code
+in the generated dispatch path will fail there.
+
+`TreatWarningsAsErrors` and `EnforceCodeStyleInBuild` are on: a build with any
+warning fails. Please don't suppress warnings to get past this; fix the cause or
+raise it in the PR discussion.
+
+## Public API Baselines
+
+The public surface of every shipped package is frozen in
+`tests/Mediant.UnitTests/PublicApi/<Assembly>.approved.txt` and verified by
+`PublicApiTests`. If your change intentionally alters the public API:
+
+1. Run the unit tests — the failing test writes a `<Assembly>.received.txt`
+   next to the test binaries.
+2. Review the diff, then copy the received file over the matching
+   `approved.txt` baseline and commit it.
+3. Call out the API change explicitly in your PR description. Breaking changes
+   need a very good reason after 1.0.
+
+## Pull Requests
+
+- Open an issue first for anything non-trivial, so the approach can be agreed on
+  before you invest time.
+- Branch from `main`; keep PRs focused on one logical change.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for the PR
+  title (it becomes the squash commit), e.g. `fix(behaviors): ...`,
+  `feat(aspnetcore): ...`, `docs: ...`.
+- Add tests for new functionality and regression tests for bug fixes.
+- Update `docs/CHANGELOG.md` under an `Unreleased` heading for user-visible
+  changes.
+- Fill in the PR template checklist.
+
+## Reporting Issues
+
+Use the issue templates for bug reports and feature requests. For security
+vulnerabilities, **do not open a public issue** — follow [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+Security fixes are released for the latest stable version. Pre-release versions
+(`-preview`, `-rc`) are not supported once the corresponding stable version ships.
+
+This policy covers all packages shipped from this repository:
+`Mediant`, `Mediant.Contracts`, `Mediant.Behaviors`, `Mediant.FluentValidation`,
+`Mediant.AspNetCore`, `Mediant.EntityFrameworkCore`, `Mediant.Analyzers`,
+and `Mediant.SourceGenerator`.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/omercelikdev/mediant/security/advisories/new)
+(preferred), or by email to **omer@omercelik.dev** with the subject line
+`[SECURITY] mediant`.
+
+Please include as much of the following as you can:
+
+- The affected package(s) and version(s)
+- A description of the vulnerability and its impact
+- Steps to reproduce, ideally a minimal proof of concept
+- Any suggested mitigation or fix
+
+## What to Expect
+
+- **Acknowledgement** within 48 hours of your report.
+- **Assessment** and severity triage within 7 days.
+- **Fix and release**: confirmed vulnerabilities are fixed as fast as severity
+  demands; a patched version is published to NuGet.org and a security advisory
+  is issued crediting the reporter (unless you prefer to remain anonymous).
+
+Please give us a reasonable window to ship a fix before any public disclosure.


### PR DESCRIPTION
## What

Adds the missing OSS/enterprise hygiene files ahead of the 1.0 stable release:

- **SECURITY.md** — private vulnerability reporting via GitHub Security Advisories (or email), supported-versions policy, response expectations. Covers all 8 shipped packages.
- **CONTRIBUTING.md** — build/test instructions, TreatWarningsAsErrors note, the public API baseline workflow (received.txt → approved.txt), Conventional Commits PR conventions.
- **.github/dependabot.yml** — weekly grouped update PRs for NuGet packages and GitHub Actions.

## Why

Part of the 1.0 stable release checklist: a public security disclosure channel and contributor onboarding docs are table stakes for the "enterprise-grade" positioning; Dependabot keeps dependencies patched going forward.

## Checklist

- [x] All tests pass (`dotnet test`) — docs/config only, no code changes
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed
- [ ] Added tests for new functionality — N/A