### PR TITLE
ci(release): run analyzer, source-generator, and EF Core tests before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
         run: |
           dotnet test tests/Mediant.UnitTests/ --no-build --configuration Release
           dotnet test tests/Mediant.IntegrationTests/ --no-build --configuration Release
+          dotnet test tests/Mediant.Analyzers.Tests/ --no-build --configuration Release
+          dotnet test tests/Mediant.SourceGenerator.Tests/ --no-build --configuration Release
+          dotnet test tests/Mediant.EntityFrameworkCore.Tests/ --no-build --configuration Release
 
       - name: Pack
         run: |


### PR DESCRIPTION
## What

The Release workflow only ran unit and integration tests before packing and pushing to NuGet.org. This adds the remaining test projects that gate CI on `main` — `Mediant.Analyzers.Tests`, `Mediant.SourceGenerator.Tests`, and `Mediant.EntityFrameworkCore.Tests` — so a release tag cannot publish packages that CI would have rejected.

Load tests are intentionally left out of the release gate (they are timing-sensitive and already run on every push to `main`).

## Why

Part of the 1.0 stable release checklist: the analyzer and source-generator packages are shipped artifacts, so their test suites should gate the publish step too. Cheap insurance — adds ~2s to the release job.

## Checklist

- [x] All tests pass (`dotnet test`) — full local suite green (337 tests, 0 failures)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — N/A
- [ ] Added tests for new functionality — N/A (CI config only)