### PR TITLE
docs(changelog): update 1.0.0 release date to 2026-07-03

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2026-06-30
+## [1.0.0] - 2026-07-03
 
 First stable release. This release hardens correctness and concurrency across the whole pipeline.
 


### PR DESCRIPTION
## What

Updates the `[1.0.0]` heading date in `docs/CHANGELOG.md` from 2026-06-30 (when the entry was drafted) to 2026-07-03, the actual stable release date.

## Why

The GitHub Release and package metadata link to this changelog; the date should match the day `v1.0.0` is tagged.

## Checklist

- [x] All tests pass (`dotnet test`) — docs only
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed
- [ ] Added tests for new functionality — N/A