### PR TITLE
ci: bump actions to current majors (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         dotnet-version: [ '8.0.x', '9.0.x', '10.0.x' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
@@ -55,10 +55,10 @@ jobs:
     name: Native AOT publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -83,10 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -101,7 +101,7 @@ jobs:
             --configuration Release
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/**/coverage.cobertura.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,15 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
 
@@ -36,6 +36,6 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:csharp"

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -21,9 +21,9 @@ jobs:
     name: Build Dashboard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dashboard/dist
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## What

Clears the Node 20 deprecation annotations by bumping every action across the four workflows to its current major:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-dotnet` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `softprops/action-gh-release` | v2 | v3 |
| `github/codeql-action` | v3 | v4 |

`NuGet/login@v1` is already current. All bumps are Node 24 runtime moves with unchanged inputs — `action-gh-release` v3 release notes explicitly state it is runtime-only; CodeQL v4 keeps the same `init`/`analyze` interface.

## Why

The v1.0.0 release run annotated: *"Node.js 20 is deprecated ... forced to run on Node.js 24"*. Dependabot (now enabled) would eventually PR these one by one; this clears them in one pass.

## Verification

- CI on this PR exercises checkout, setup-dotnet, setup-node, and upload-artifact.
- CodeQL and Dashboard Deploy workflows run on merge to `main`.
- Release workflow changes (gh-release v3, setup-dotnet v5) get exercised on the next tag.

## Checklist

- [x] All tests pass (`dotnet test`) — workflow config only
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — N/A
- [ ] Added tests for new functionality — N/A