### PR TITLE
ci(codeql): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+  workflow_dispatch:
 
 concurrency:
   group: codeql-${{ github.ref }}


### PR DESCRIPTION
## What

Adds `workflow_dispatch:` to the CodeQL workflow so it can be run manually from the Actions tab (or `gh workflow run`).

## Why

CodeQL has not run since 2026-06-01: the repo was idle April–June, so GitHub disabled the workflow for inactivity, and the July pushes (including the repo transfer and the v1.0.0 release) were never scanned. Editing the workflow file re-enables it; the manual trigger gives us a way to run a scan on demand — starting with one against current `main` right after this merges, so 1.0.0 ships with a fresh CodeQL analysis.

This PR itself should also trigger a `pull_request` CodeQL run, confirming event triggers work again.

## Checklist

- [x] All tests pass (`dotnet test`) — workflow config only
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — N/A
- [ ] Added tests for new functionality — N/A