### PR TITLE
fix(outbox): enforce MaxAttempts so poison messages stop retrying

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-07-03
+
+### Fixed
+- **Outbox `MaxAttempts` is now enforced** (#120) — `OutboxProcessor` no longer redispatches messages that have already failed `MaxAttempts` times. Previously the limit was documented but never checked, so a poison message (e.g. an unresolvable notification type) was retried on every poll forever. Abandonment is logged once per message. Messages that reached the limit before this fix stop being retried after upgrade.
+
 ## [1.0.0] - 2026-07-03
 
 First stable release. This release hardens correctness and concurrency across the whole pipeline.

--- a/src/Mediant.Behaviors/Outbox/OutboxProcessor.cs
+++ b/src/Mediant.Behaviors/Outbox/OutboxProcessor.cs
@@ -39,6 +39,11 @@ public sealed class OutboxProcessor : BackgroundService
     private readonly OutboxProcessorOptions _options;
     private readonly ILogger<OutboxProcessor> _logger;
 
+    // Ids whose abandonment has already been logged, so a poison message that stays in the store
+    // is reported once per process lifetime instead of on every poll. Guarded because
+    // ProcessPendingAsync is public for deterministic testing.
+    private readonly HashSet<Guid> _abandonmentLogged = new();
+
     /// <summary>Initializes a new instance of <see cref="OutboxProcessor"/>.</summary>
     public OutboxProcessor(
         IServiceScopeFactory scopeFactory,
@@ -91,6 +96,25 @@ public sealed class OutboxProcessor : BackgroundService
         for (int i = 0; i < pending.Count; i++)
         {
             var message = pending[i];
+
+            if (message.Attempts >= _options.MaxAttempts)
+            {
+                bool firstTime;
+                lock (_abandonmentLogged)
+                {
+                    firstTime = _abandonmentLogged.Add(message.Id);
+                }
+
+                if (firstTime)
+                {
+                    _logger.LogError(
+                        "Outbox message {MessageId} abandoned after {Attempts} attempts (MaxAttempts: {MaxAttempts}); it will not be retried. Last error: {Error}",
+                        message.Id, message.Attempts, _options.MaxAttempts, message.Error);
+                }
+
+                continue;
+            }
+
             try
             {
                 var notification = Rehydrate(message, _options.SerializerOptions ?? DefaultOutbox.DefaultSerializerOptions);

--- a/tests/Mediant.UnitTests/Behaviors/OutboxTests.cs
+++ b/tests/Mediant.UnitTests/Behaviors/OutboxTests.cs
@@ -101,6 +101,54 @@ public class OutboxTests
         message.Error.Should().NotBeNullOrEmpty();
     }
 
+    [Fact]
+    public async Task Processor_Abandons_Message_After_MaxAttempts()
+    {
+        var sink = new OutboxSink();
+        var sp = BuildProvider(sink);
+
+        using (var scope = sp.CreateScope())
+        {
+            await scope.ServiceProvider.GetRequiredService<IOutbox>().EnqueueAsync(new FailingOutboxEvent());
+        }
+
+        var processor = NewProcessor(sp, new OutboxProcessorOptions { MaxAttempts = 2 });
+
+        // Attempts 1 and 2 dispatch (and fail); every later poll must skip the message.
+        await processor.ProcessPendingAsync(default);
+        await processor.ProcessPendingAsync(default);
+        await processor.ProcessPendingAsync(default);
+        await processor.ProcessPendingAsync(default);
+
+        var store = (InMemoryOutboxStore)sp.GetRequiredService<IOutboxStore>();
+        var message = store.GetAll().Should().ContainSingle().Subject;
+        message.Attempts.Should().Be(2, "dispatch must stop once MaxAttempts is reached");
+        message.ProcessedOn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Processor_Still_Dispatches_Other_Messages_When_One_Is_Abandoned()
+    {
+        var sink = new OutboxSink();
+        var sp = BuildProvider(sink);
+
+        using (var scope = sp.CreateScope())
+        {
+            var outbox = scope.ServiceProvider.GetRequiredService<IOutbox>();
+            await outbox.EnqueueAsync(new FailingOutboxEvent());
+            await outbox.EnqueueAsync(new OutboxEvent("healthy"));
+        }
+
+        var processor = NewProcessor(sp, new OutboxProcessorOptions { MaxAttempts = 1 });
+
+        await processor.ProcessPendingAsync(default); // poison fails (attempt 1), healthy dispatches
+        await processor.ProcessPendingAsync(default); // poison skipped, nothing left to dispatch
+
+        sink.Received.Should().ContainSingle().Which.Should().Be("healthy");
+        var store = (InMemoryOutboxStore)sp.GetRequiredService<IOutboxStore>();
+        store.GetAll().Single(m => m.ProcessedOn is null).Attempts.Should().Be(1);
+    }
+
     private static ServiceProvider BuildProvider(OutboxSink sink)
     {
         var services = new ServiceCollection();
@@ -111,10 +159,10 @@ public class OutboxTests
         return services.BuildServiceProvider();
     }
 
-    private static OutboxProcessor NewProcessor(IServiceProvider sp)
+    private static OutboxProcessor NewProcessor(IServiceProvider sp, OutboxProcessorOptions? options = null)
         => new(
             sp.GetRequiredService<IServiceScopeFactory>(),
-            sp.GetRequiredService<IOptions<OutboxProcessorOptions>>(),
+            options is null ? sp.GetRequiredService<IOptions<OutboxProcessorOptions>>() : Options.Create(options),
             sp.GetRequiredService<ILogger<OutboxProcessor>>());
 }
 


### PR DESCRIPTION
## What

Fixes #120. `OutboxProcessor.ProcessPendingAsync` now skips messages whose `Attempts` already reached `OutboxProcessorOptions.MaxAttempts` instead of redispatching them on every poll interval forever. Abandonment is logged once per message (per process lifetime), including the last error, so a poison message is visible without spamming logs.

Also prepares the **v1.0.1 patch release**: version bump in `Directory.Build.props` and the changelog entry.

## Why

`MaxAttempts` was documented (*"Maximum dispatch attempts before a message is left as failed. Default 5."*) but never checked anywhere — not in the processor, not in `EfOutboxStore`, not in `InMemoryOutboxStore`. A message that can never dispatch (e.g. renamed notification type) was retried indefinitely.

No API change — this makes the code match the documented behavior, hence patch-level.

Known limitation (documented trade-off, store-level filtering lands with the #116 claim/lease work in v1.1.0): abandoned messages still occupy slots in the fetched batch; if abandoned messages ever exceed `BatchSize`, newer messages behind them would wait. With default settings that requires 100+ poison messages.

## Tests

- `Processor_Abandons_Message_After_MaxAttempts` — attempts stop exactly at the limit across repeated polls
- `Processor_Still_Dispatches_Other_Messages_When_One_Is_Abandoned` — healthy traffic unaffected

Full suite: 339 tests, 0 failures.

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG
- [x] Added tests for new functionality