### PR TITLE
feat(behaviors): make the performance hard ceiling configurable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Configurable performance hard ceiling** (#118) — the fixed 30-second ceiling in `PerformanceBehavior` (always logged as Critical) is now configurable: globally via `PerformanceBehaviorOptions.HardCeilingMs` (default 30000, `<= 0` disables) and per request type via `[PerformanceThreshold(CeilingMs = ...)]` (`0` = use global, negative = disabled for that request — long-running batch commands by design).
+
 ## [1.0.1] - 2026-07-03
 
 ### Fixed

--- a/src/Mediant.Behaviors/Attributes/PerformanceThresholdAttribute.cs
+++ b/src/Mediant.Behaviors/Attributes/PerformanceThresholdAttribute.cs
@@ -17,4 +17,12 @@ public sealed class PerformanceThresholdAttribute : Attribute
     /// Requests exceeding this duration are logged at Error level.
     /// </summary>
     public int CriticalMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hard-ceiling override in milliseconds for this request type; above it the
+    /// request is always logged as Critical. When 0 (default) the global
+    /// <c>PerformanceBehaviorOptions.HardCeilingMs</c> applies. Set a negative value to disable
+    /// the ceiling for this request type (long-running by design, e.g. batch commands).
+    /// </summary>
+    public int CeilingMs { get; set; }
 }

--- a/src/Mediant.Behaviors/Behaviors/PerformanceBehavior.cs
+++ b/src/Mediant.Behaviors/Behaviors/PerformanceBehavior.cs
@@ -77,12 +77,17 @@ public sealed class PerformanceBehavior<TRequest, TResponse> : IPipelineBehavior
             ? CachedAttribute.CriticalMs
             : _options.CriticalThresholdMs;
 
-        // Over 30 seconds — always critical regardless of thresholds
-        if (elapsedMs > 30_000)
+        // Attribute: 0 = unset (use global), negative = ceiling disabled for this request type.
+        var ceilingMs = CachedAttribute is not null && CachedAttribute.CeilingMs != 0
+            ? CachedAttribute.CeilingMs
+            : _options.HardCeilingMs;
+
+        // Over the hard ceiling — always critical regardless of thresholds
+        if (ceilingMs > 0 && elapsedMs > ceilingMs)
         {
             _logger.LogCritical(
-                "CRITICAL: {RequestName} took {ElapsedMs}ms (over 30s threshold)",
-                requestName, elapsedMs);
+                "CRITICAL: {RequestName} took {ElapsedMs}ms (over {CeilingMs}ms hard ceiling)",
+                requestName, elapsedMs, ceilingMs);
         }
         else if (elapsedMs > criticalMs)
         {

--- a/src/Mediant.Behaviors/Configuration/BehaviorOptions.cs
+++ b/src/Mediant.Behaviors/Configuration/BehaviorOptions.cs
@@ -43,6 +43,14 @@ public sealed class PerformanceBehaviorOptions
     public int CriticalThresholdMs { get; set; } = 5000;
 
     /// <summary>
+    /// Gets or sets the hard ceiling in milliseconds above which a request is always logged as
+    /// Critical, regardless of the warning/critical thresholds. Default is 30000 (30 seconds).
+    /// Set to 0 or a negative value to disable the ceiling (e.g. when long-running batch commands
+    /// are expected). Per-request override: <see cref="Attributes.PerformanceThresholdAttribute.CeilingMs"/>.
+    /// </summary>
+    public int HardCeilingMs { get; set; } = 30_000;
+
+    /// <summary>
     /// Gets or sets whether performance monitoring is enabled.
     /// </summary>
     public bool Enabled { get; set; } = true;

--- a/tests/Mediant.UnitTests/Behaviors/PerformanceBehaviorTests.cs
+++ b/tests/Mediant.UnitTests/Behaviors/PerformanceBehaviorTests.cs
@@ -110,6 +110,110 @@ public class PerformanceBehaviorTests
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
+    [Fact]
+    public async Task Should_Log_Critical_When_Hard_Ceiling_Exceeded()
+    {
+        var logger = Substitute.For<ILogger<PerformanceBehavior<TestCommand, Result>>>();
+        // Ceiling of 1ms — a 20ms handler must land above it without waiting 30 real seconds.
+        var opts = Options.Create(new PerformanceBehaviorOptions
+        {
+            WarningThresholdMs = 60_000,
+            CriticalThresholdMs = 60_000,
+            HardCeilingMs = 1,
+        });
+        var behavior = new PerformanceBehavior<TestCommand, Result>(logger, opts);
+
+        RequestHandlerDelegate<Result> next = async () =>
+        {
+            await Task.Delay(20);
+            return Result.Success();
+        };
+
+        await behavior.Handle(new TestCommand("test"), next, CancellationToken.None);
+
+        logger.Received().Log(
+            LogLevel.Critical,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("hard ceiling")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Attribute_Ceiling_Overrides_Global_Ceiling()
+    {
+        var logger = Substitute.For<ILogger<PerformanceBehavior<LowCeilingCommand, Result>>>();
+        // Global ceiling stays at the 30s default; the attribute pulls it down to 1ms.
+        var opts = Options.Create(new PerformanceBehaviorOptions
+        {
+            WarningThresholdMs = 60_000,
+            CriticalThresholdMs = 60_000,
+        });
+        var behavior = new PerformanceBehavior<LowCeilingCommand, Result>(logger, opts);
+
+        RequestHandlerDelegate<Result> next = async () =>
+        {
+            await Task.Delay(20);
+            return Result.Success();
+        };
+
+        await behavior.Handle(new LowCeilingCommand("test"), next, CancellationToken.None);
+
+        logger.Received().Log(
+            LogLevel.Critical,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("hard ceiling")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Negative_Attribute_Ceiling_Disables_Ceiling_For_Request_Type()
+    {
+        var logger = Substitute.For<ILogger<PerformanceBehavior<NoCeilingCommand, Result>>>();
+        // Global ceiling of 1ms would fire for any handler — the attribute disables it.
+        var opts = Options.Create(new PerformanceBehaviorOptions
+        {
+            WarningThresholdMs = 60_000,
+            CriticalThresholdMs = 60_000,
+            HardCeilingMs = 1,
+        });
+        var behavior = new PerformanceBehavior<NoCeilingCommand, Result>(logger, opts);
+
+        RequestHandlerDelegate<Result> next = async () =>
+        {
+            await Task.Delay(20);
+            return Result.Success();
+        };
+
+        await behavior.Handle(new NoCeilingCommand("test"), next, CancellationToken.None);
+
+        logger.DidNotReceive().Log(
+            LogLevel.Critical,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}
+
+[PerformanceThreshold(CeilingMs = 1)]
+public sealed record LowCeilingCommand(string Data) : ICommand<Result>;
+
+public sealed class LowCeilingCommandHandler : ICommandHandler<LowCeilingCommand>
+{
+    public ValueTask<Result> Handle(LowCeilingCommand request, CancellationToken cancellationToken)
+        => new(Result.Success());
+}
+
+// Long-running by design — the negative ceiling opts this request type out of the hard ceiling.
+[PerformanceThreshold(CeilingMs = -1)]
+public sealed record NoCeilingCommand(string Data) : ICommand<Result>;
+
+public sealed class NoCeilingCommandHandler : ICommandHandler<NoCeilingCommand>
+{
+    public ValueTask<Result> Handle(NoCeilingCommand request, CancellationToken cancellationToken)
+        => new(Result.Success());
 }
 
 // CriticalMs is set high so the handler's small delay (1ms+) reliably lands in the WARNING band

--- a/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
+++ b/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
@@ -39,6 +39,7 @@ namespace Mediant.Behaviors.Attributes
     public sealed class PerformanceThresholdAttribute : System.Attribute
     {
         public PerformanceThresholdAttribute() { }
+        public int CeilingMs { get; set; }
         public int CriticalMs { get; set; }
         public int WarningMs { get; set; }
     }
@@ -181,6 +182,7 @@ namespace Mediant.Behaviors.Configuration
         public PerformanceBehaviorOptions() { }
         public int CriticalThresholdMs { get; set; }
         public bool Enabled { get; set; }
+        public int HardCeilingMs { get; set; }
         public int WarningThresholdMs { get; set; }
     }
     public sealed class RetryBehaviorOptions


### PR DESCRIPTION
## What

Closes #118. The fixed `elapsedMs > 30_000` always-critical check in `PerformanceBehavior` is now configurable:

- **Global:** `PerformanceBehaviorOptions.HardCeilingMs` — default **30000** (unchanged behavior), `<= 0` disables the ceiling.
- **Per request type:** `[PerformanceThreshold(CeilingMs = ...)]` — `0` (default) falls back to the global value; a **negative** value disables the ceiling for that request type only (long-running batch/worker commands by design).

The critical log line now includes the effective ceiling value instead of hardcoded "30s".

## Why

Dfx batch/worker commands legitimately run past 30 seconds; today each execution logs a Critical entry that pages on-call for expected behavior. Defaults are unchanged, so existing consumers see no difference. Additive API only → lands in **v1.1.0**.

## Tests

- `Should_Log_Critical_When_Hard_Ceiling_Exceeded` — configurable global ceiling fires
- `Attribute_Ceiling_Overrides_Global_Ceiling` — per-request override wins over the 30s default
- `Negative_Attribute_Ceiling_Disables_Ceiling_For_Request_Type` — opt-out works
- Public API baseline (`Mediant.Behaviors.approved.txt`) updated for the two new properties

Full suite: 342 tests, 0 failures.

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG (Unreleased)
- [x] Added tests for new functionality