### PR TITLE
feat(idempotency): expose begin/complete lifecycle via IIdempotentOperationCoordinator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Idempotency coordinator for non-mediator entry points** (#114) — `IIdempotentOperationCoordinator` (default implementation `DefaultIdempotentOperationCoordinator`, registered via `AddMediantIdempotencyCoordinator()` or automatically with `AddMediantDistributedCacheIdempotencyStore()`) exposes the begin/complete idempotency lifecycle — per-key locking, stored-response replay, optional payload-fingerprint verification (`FingerprintMismatch`), and optional lock-wait timeout (`InFlight`, for 409-style HTTP semantics) — so an HTTP `Idempotency-Key` middleware can share the same store and semantics as the `[Idempotent]` behavior. The serialization guarantee is process-local; responses are persisted in an `IdempotencyEntry<TResponse>` envelope.
 - **Configurable performance hard ceiling** (#118) — the fixed 30-second ceiling in `PerformanceBehavior` (always logged as Critical) is now configurable: globally via `PerformanceBehaviorOptions.HardCeilingMs` (default 30000, `<= 0` disables) and per request type via `[PerformanceThreshold(CeilingMs = ...)]` (`0` = use global, negative = disabled for that request — long-running batch commands by design).
 
 ## [1.0.1] - 2026-07-03

--- a/src/Mediant.Behaviors/Behaviors/BoundedLockPool.cs
+++ b/src/Mediant.Behaviors/Behaviors/BoundedLockPool.cs
@@ -49,6 +49,33 @@ internal sealed class BoundedLockPool
         return new Releaser(this, entry);
     }
 
+    /// <summary>
+    /// Attempts to acquire the per-key lock within <paramref name="timeout"/>. Returns null when
+    /// the lock was not acquired in time (another caller holds it).
+    /// </summary>
+    internal async ValueTask<Releaser?> TryAcquireAsync(string key, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var entry = Rent(key);
+        bool acquired;
+        try
+        {
+            acquired = await entry.Semaphore.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            Return(entry);
+            throw;
+        }
+
+        if (!acquired)
+        {
+            Return(entry);
+            return null;
+        }
+
+        return new Releaser(this, entry);
+    }
+
     private LockEntry Rent(string key)
     {
         while (true)

--- a/src/Mediant.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
+++ b/src/Mediant.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
@@ -139,6 +139,20 @@ public static class BehaviorServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         services.TryAddSingleton<IIdempotencyStore, Idempotency.DistributedCacheIdempotencyStore>();
+        services.TryAddSingleton<Idempotency.IIdempotentOperationCoordinator, Idempotency.DefaultIdempotentOperationCoordinator>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="Idempotency.IIdempotentOperationCoordinator"/> so non-mediator
+    /// entry points (e.g. an HTTP <c>Idempotency-Key</c> middleware) can share the idempotency
+    /// begin/complete lifecycle and store with the <c>[Idempotent]</c> behavior. Requires an
+    /// <see cref="IIdempotencyStore"/> registration.
+    /// </summary>
+    public static IServiceCollection AddMediantIdempotencyCoordinator(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddSingleton<Idempotency.IIdempotentOperationCoordinator, Idempotency.DefaultIdempotentOperationCoordinator>();
         return services;
     }
 

--- a/src/Mediant.Behaviors/Idempotency/DefaultIdempotentOperationCoordinator.cs
+++ b/src/Mediant.Behaviors/Idempotency/DefaultIdempotentOperationCoordinator.cs
@@ -1,0 +1,76 @@
+using Mediant.Abstractions;
+using Mediant.Behaviors.Behaviors;
+
+namespace Mediant.Behaviors.Idempotency;
+
+/// <summary>
+/// Default <see cref="IIdempotentOperationCoordinator"/> backed by a bounded per-key lock pool and
+/// the registered <see cref="IIdempotencyStore"/>. Register as a singleton so all entry points in
+/// the process serialize on the same locks.
+/// </summary>
+public sealed class DefaultIdempotentOperationCoordinator : IIdempotentOperationCoordinator
+{
+    private readonly IIdempotencyStore? _store;
+    private readonly BoundedLockPool _keyLocks = new();
+
+    /// <summary>Initializes a new instance of <see cref="DefaultIdempotentOperationCoordinator"/>.</summary>
+    /// <param name="store">The idempotency store; required at first use.</param>
+    public DefaultIdempotentOperationCoordinator(IIdempotencyStore? store = null)
+    {
+        _store = store;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IdempotentOperation<TResponse>> BeginAsync<TResponse>(
+        string key,
+        string? fingerprint = null,
+        TimeSpan? lockWaitTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        if (_store is null)
+        {
+            throw new InvalidOperationException(
+                "No IIdempotencyStore is registered. Register one (e.g. AddMediantDistributedCacheIdempotencyStore()) before using the coordinator.");
+        }
+
+        BoundedLockPool.Releaser releaser;
+        if (lockWaitTimeout is null)
+        {
+            releaser = await _keyLocks.AcquireAsync(key, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var acquired = await _keyLocks.TryAcquireAsync(key, lockWaitTimeout.Value, cancellationToken).ConfigureAwait(false);
+            if (acquired is null)
+            {
+                return new IdempotentOperation<TResponse>(
+                    IdempotentOperationStatus.InFlight, default, _store, key, fingerprint, lockReleaser: null);
+            }
+
+            releaser = acquired.Value;
+        }
+
+        try
+        {
+            var entry = await _store.GetAsync<IdempotencyEntry<TResponse>>(key, cancellationToken).ConfigureAwait(false);
+            if (entry is not null)
+            {
+                var status = fingerprint is not null && entry.Fingerprint is not null && !string.Equals(fingerprint, entry.Fingerprint, StringComparison.Ordinal)
+                    ? IdempotentOperationStatus.FingerprintMismatch
+                    : IdempotentOperationStatus.Replay;
+
+                return new IdempotentOperation<TResponse>(status, entry.Response, _store, key, fingerprint, releaser);
+            }
+
+            return new IdempotentOperation<TResponse>(
+                IdempotentOperationStatus.New, default, _store, key, fingerprint, releaser);
+        }
+        catch
+        {
+            releaser.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/Mediant.Behaviors/Idempotency/IIdempotentOperationCoordinator.cs
+++ b/src/Mediant.Behaviors/Idempotency/IIdempotentOperationCoordinator.cs
@@ -1,0 +1,38 @@
+namespace Mediant.Behaviors.Idempotency;
+
+/// <summary>
+/// Exposes the idempotency begin/complete lifecycle (per-key locking, stored-response replay,
+/// optional payload-fingerprint verification) to non-mediator entry points such as an HTTP
+/// <c>Idempotency-Key</c> middleware, backed by the same <see cref="Mediant.Abstractions.IIdempotencyStore"/>
+/// the <c>[Idempotent]</c> pipeline behavior uses.
+/// <para>
+/// The per-key serialization guarantee is <b>process-local</b>: concurrent callers within one
+/// process are serialized on the key, but replicas of a horizontally scaled service can still race
+/// on the same key (last write wins at the store). Keys are used verbatim — namespace them
+/// (e.g. <c>"http:orders:{key}"</c>) to avoid colliding with other producers on a shared store.
+/// </para>
+/// </summary>
+public interface IIdempotentOperationCoordinator
+{
+    /// <summary>
+    /// Begins an idempotent operation for <paramref name="key"/>: acquires the per-key lock and
+    /// checks the store for a previously completed result. Inspect
+    /// <see cref="IdempotentOperation{TResponse}.Status"/> on the returned handle, and always
+    /// dispose it to release the lock.
+    /// </summary>
+    /// <typeparam name="TResponse">The response type stored for the operation.</typeparam>
+    /// <param name="key">The idempotency key, used verbatim.</param>
+    /// <param name="fingerprint">Optional payload fingerprint. When supplied and a stored entry
+    /// carries a different fingerprint, the status is
+    /// <see cref="IdempotentOperationStatus.FingerprintMismatch"/> instead of a silent replay.</param>
+    /// <param name="lockWaitTimeout">How long to wait for the per-key lock. Null (default) waits
+    /// indefinitely — the behavior's semantics. A finite value (e.g. <see cref="TimeSpan.Zero"/>)
+    /// yields <see cref="IdempotentOperationStatus.InFlight"/> when the lock is not acquired in
+    /// time, enabling 409-style HTTP responses.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    ValueTask<IdempotentOperation<TResponse>> BeginAsync<TResponse>(
+        string key,
+        string? fingerprint = null,
+        TimeSpan? lockWaitTimeout = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Mediant.Behaviors/Idempotency/IdempotencyEntry.cs
+++ b/src/Mediant.Behaviors/Idempotency/IdempotencyEntry.cs
@@ -1,0 +1,17 @@
+namespace Mediant.Behaviors.Idempotency;
+
+/// <summary>
+/// Serialization envelope the <see cref="IIdempotentOperationCoordinator"/> persists in the
+/// <see cref="Mediant.Abstractions.IIdempotencyStore"/>: the operation's response plus the optional
+/// payload fingerprint used to detect key reuse with a different payload.
+/// </summary>
+/// <typeparam name="TResponse">The stored response type.</typeparam>
+public sealed class IdempotencyEntry<TResponse>
+{
+    /// <summary>SHA-256 (or caller-defined) fingerprint of the request payload, or null when
+    /// fingerprint checking is not used.</summary>
+    public string? Fingerprint { get; init; }
+
+    /// <summary>The stored operation response.</summary>
+    public TResponse? Response { get; init; }
+}

--- a/src/Mediant.Behaviors/Idempotency/IdempotentOperation.cs
+++ b/src/Mediant.Behaviors/Idempotency/IdempotentOperation.cs
@@ -1,0 +1,79 @@
+using Mediant.Abstractions;
+using Mediant.Behaviors.Behaviors;
+
+namespace Mediant.Behaviors.Idempotency;
+
+/// <summary>
+/// Handle for one idempotent operation begun via
+/// <see cref="IIdempotentOperationCoordinator.BeginAsync{TResponse}"/>. Holds the per-key lock for
+/// its lifetime (except <see cref="IdempotentOperationStatus.InFlight"/>) — always dispose it.
+/// </summary>
+/// <typeparam name="TResponse">The response type stored for the operation.</typeparam>
+public sealed class IdempotentOperation<TResponse> : IDisposable
+{
+    private readonly IIdempotencyStore? _store;
+    private readonly string _key;
+    private readonly string? _fingerprint;
+    private BoundedLockPool.Releaser? _lockReleaser;
+    private bool _completed;
+
+    internal IdempotentOperation(
+        IdempotentOperationStatus status,
+        TResponse? storedResponse,
+        IIdempotencyStore? store,
+        string key,
+        string? fingerprint,
+        BoundedLockPool.Releaser? lockReleaser)
+    {
+        Status = status;
+        StoredResponse = storedResponse;
+        _store = store;
+        _key = key;
+        _fingerprint = fingerprint;
+        _lockReleaser = lockReleaser;
+    }
+
+    /// <summary>The outcome of beginning the operation.</summary>
+    public IdempotentOperationStatus Status { get; }
+
+    /// <summary>The previously stored response when <see cref="Status"/> is
+    /// <see cref="IdempotentOperationStatus.Replay"/>; default otherwise.</summary>
+    public TResponse? StoredResponse { get; }
+
+    /// <summary>
+    /// Persists the operation's response (with the fingerprint passed to
+    /// <c>BeginAsync</c>, if any) so later calls with the same key replay it for
+    /// <paramref name="window"/>. Only valid when <see cref="Status"/> is
+    /// <see cref="IdempotentOperationStatus.New"/>, at most once, while the handle is undisposed.
+    /// If the operation fails, dispose without completing — nothing is stored and a retry can run.
+    /// </summary>
+    /// <param name="response">The response to store.</param>
+    /// <param name="window">How long the stored response replays.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async ValueTask CompleteAsync(TResponse response, TimeSpan window, CancellationToken cancellationToken = default)
+    {
+        if (Status != IdempotentOperationStatus.New)
+        {
+            throw new InvalidOperationException(
+                $"CompleteAsync is only valid for a {nameof(IdempotentOperationStatus.New)} operation (status: {Status}).");
+        }
+
+        if (_completed)
+        {
+            throw new InvalidOperationException("CompleteAsync was already called for this operation.");
+        }
+
+        ObjectDisposedException.ThrowIf(_lockReleaser is null, this);
+
+        var entry = new IdempotencyEntry<TResponse> { Fingerprint = _fingerprint, Response = response };
+        await _store!.SetAsync(_key, entry, window, cancellationToken).ConfigureAwait(false);
+        _completed = true;
+    }
+
+    /// <summary>Releases the per-key lock. Safe to call multiple times.</summary>
+    public void Dispose()
+    {
+        _lockReleaser?.Dispose();
+        _lockReleaser = null;
+    }
+}

--- a/src/Mediant.Behaviors/Idempotency/IdempotentOperationStatus.cs
+++ b/src/Mediant.Behaviors/Idempotency/IdempotentOperationStatus.cs
@@ -1,0 +1,34 @@
+namespace Mediant.Behaviors.Idempotency;
+
+/// <summary>
+/// Outcome of <see cref="IIdempotentOperationCoordinator.BeginAsync{TResponse}"/>.
+/// </summary>
+public enum IdempotentOperationStatus
+{
+    /// <summary>
+    /// No stored result exists for the key — the caller owns the operation and must either
+    /// execute it and call <see cref="IdempotentOperation{TResponse}.CompleteAsync"/> or dispose
+    /// without completing (leaving no trace, so a later retry can run).
+    /// </summary>
+    New = 0,
+
+    /// <summary>
+    /// A result is already stored for the key (and the fingerprint matched, when one was
+    /// supplied) — serve <see cref="IdempotentOperation{TResponse}.StoredResponse"/> instead of
+    /// executing again.
+    /// </summary>
+    Replay = 1,
+
+    /// <summary>
+    /// Another caller currently holds the per-key lock and the requested wait timeout elapsed.
+    /// Only returned when a finite lock-wait timeout was passed to
+    /// <see cref="IIdempotentOperationCoordinator.BeginAsync{TResponse}"/> (HTTP semantics: 409).
+    /// </summary>
+    InFlight = 2,
+
+    /// <summary>
+    /// A result is stored for the key but it was produced from a payload with a different
+    /// fingerprint — the key is being reused for a different request (HTTP semantics: 422).
+    /// </summary>
+    FingerprintMismatch = 3,
+}

--- a/tests/Mediant.UnitTests/Idempotency/IdempotentOperationCoordinatorTests.cs
+++ b/tests/Mediant.UnitTests/Idempotency/IdempotentOperationCoordinatorTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Concurrent;
+using Mediant.Abstractions;
+using Mediant.Behaviors.Idempotency;
+
+namespace Mediant.UnitTests.Idempotency;
+
+public class IdempotentOperationCoordinatorTests
+{
+    [Fact]
+    public async Task New_Operation_Completes_And_Replays_On_Next_Begin()
+    {
+        var coordinator = NewCoordinator();
+
+        using (var op = await coordinator.BeginAsync<string>("key-1"))
+        {
+            op.Status.Should().Be(IdempotentOperationStatus.New);
+            await op.CompleteAsync("response-1", TimeSpan.FromMinutes(5));
+        }
+
+        using var replay = await coordinator.BeginAsync<string>("key-1");
+        replay.Status.Should().Be(IdempotentOperationStatus.Replay);
+        replay.StoredResponse.Should().Be("response-1");
+    }
+
+    [Fact]
+    public async Task Dispose_Without_Complete_Stores_Nothing()
+    {
+        var coordinator = NewCoordinator();
+
+        using (var op = await coordinator.BeginAsync<string>("key-fail"))
+        {
+            op.Status.Should().Be(IdempotentOperationStatus.New);
+            // Operation failed — dispose without completing.
+        }
+
+        using var retry = await coordinator.BeginAsync<string>("key-fail");
+        retry.Status.Should().Be(IdempotentOperationStatus.New, "a failed attempt must leave no entry so a retry can run");
+    }
+
+    [Fact]
+    public async Task Matching_Fingerprint_Replays()
+    {
+        var coordinator = NewCoordinator();
+
+        using (var op = await coordinator.BeginAsync<string>("key-fp", fingerprint: "abc"))
+        {
+            await op.CompleteAsync("stored", TimeSpan.FromMinutes(5));
+        }
+
+        using var replay = await coordinator.BeginAsync<string>("key-fp", fingerprint: "abc");
+        replay.Status.Should().Be(IdempotentOperationStatus.Replay);
+        replay.StoredResponse.Should().Be("stored");
+    }
+
+    [Fact]
+    public async Task Different_Fingerprint_Is_Reported_As_Mismatch()
+    {
+        var coordinator = NewCoordinator();
+
+        using (var op = await coordinator.BeginAsync<string>("key-fp2", fingerprint: "abc"))
+        {
+            await op.CompleteAsync("stored", TimeSpan.FromMinutes(5));
+        }
+
+        using var mismatch = await coordinator.BeginAsync<string>("key-fp2", fingerprint: "OTHER");
+        mismatch.Status.Should().Be(IdempotentOperationStatus.FingerprintMismatch,
+            "same key with a different payload must not silently replay");
+    }
+
+    [Fact]
+    public async Task Missing_Fingerprint_On_Either_Side_Replays()
+    {
+        var coordinator = NewCoordinator();
+
+        // Stored without a fingerprint, requested with one — verification is opt-in, so replay.
+        using (var op = await coordinator.BeginAsync<string>("key-fp3"))
+        {
+            await op.CompleteAsync("stored", TimeSpan.FromMinutes(5));
+        }
+
+        using var replay = await coordinator.BeginAsync<string>("key-fp3", fingerprint: "abc");
+        replay.Status.Should().Be(IdempotentOperationStatus.Replay);
+    }
+
+    [Fact]
+    public async Task Zero_Timeout_Reports_InFlight_While_Key_Is_Locked()
+    {
+        var coordinator = NewCoordinator();
+
+        using var first = await coordinator.BeginAsync<string>("key-busy");
+        first.Status.Should().Be(IdempotentOperationStatus.New);
+
+        using var second = await coordinator.BeginAsync<string>("key-busy", lockWaitTimeout: TimeSpan.Zero);
+        second.Status.Should().Be(IdempotentOperationStatus.InFlight);
+        second.StoredResponse.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Concurrent_Same_Key_Callers_Are_Serialized_And_Second_Replays()
+    {
+        var coordinator = NewCoordinator();
+        var executions = 0;
+
+        async Task<string> RunOnce()
+        {
+            using var op = await coordinator.BeginAsync<string>("key-concurrent");
+            if (op.Status == IdempotentOperationStatus.Replay)
+            {
+                return op.StoredResponse!;
+            }
+
+            Interlocked.Increment(ref executions);
+            await Task.Delay(25);
+            await op.CompleteAsync("only-once", TimeSpan.FromMinutes(5));
+            return "only-once";
+        }
+
+        var results = await Task.WhenAll(RunOnce(), RunOnce(), RunOnce());
+
+        executions.Should().Be(1, "concurrent same-key callers must serialize and replay the first result");
+        results.Should().AllBe("only-once");
+    }
+
+    [Fact]
+    public async Task Complete_Is_Rejected_For_Replay_And_After_Dispose()
+    {
+        var coordinator = NewCoordinator();
+
+        using (var op = await coordinator.BeginAsync<string>("key-guard"))
+        {
+            await op.CompleteAsync("stored", TimeSpan.FromMinutes(5));
+        }
+
+        using var replay = await coordinator.BeginAsync<string>("key-guard");
+        var completeReplay = () => replay.CompleteAsync("other", TimeSpan.FromMinutes(5)).AsTask();
+        await completeReplay.Should().ThrowAsync<InvalidOperationException>();
+
+        var disposed = await coordinator.BeginAsync<string>("key-guard2");
+        disposed.Dispose();
+        var completeDisposed = () => disposed.CompleteAsync("late", TimeSpan.FromMinutes(5)).AsTask();
+        await completeDisposed.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task Missing_Store_Throws_With_Clear_Message()
+    {
+        var coordinator = new DefaultIdempotentOperationCoordinator(store: null);
+
+        var act = () => coordinator.BeginAsync<string>("key").AsTask();
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*IIdempotencyStore*");
+    }
+
+    private static DefaultIdempotentOperationCoordinator NewCoordinator()
+        => new(new InMemoryIdempotencyStore());
+
+    /// <summary>Minimal in-memory IIdempotencyStore for coordinator tests.</summary>
+    private sealed class InMemoryIdempotencyStore : IIdempotencyStore
+    {
+        private readonly ConcurrentDictionary<string, object?> _entries = new(StringComparer.Ordinal);
+
+        public ValueTask<bool> ExistsAsync(string idempotencyKey, CancellationToken cancellationToken)
+            => new(_entries.ContainsKey(idempotencyKey));
+
+        public ValueTask<TResponse?> GetAsync<TResponse>(string idempotencyKey, CancellationToken cancellationToken)
+            => new(_entries.TryGetValue(idempotencyKey, out var value) && value is TResponse typed ? typed : default(TResponse?));
+
+        public ValueTask SetAsync<TResponse>(string idempotencyKey, TResponse response, TimeSpan window, CancellationToken cancellationToken)
+        {
+            _entries[idempotencyKey] = response;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask RemoveAsync(string idempotencyKey, CancellationToken cancellationToken)
+        {
+            _entries.TryRemove(idempotencyKey, out _);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
+++ b/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
@@ -222,6 +222,7 @@ namespace Mediant.Behaviors.DependencyInjection
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantCaching(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Mediant.Behaviors.Configuration.CachingBehaviorOptions>? configure = null) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantDistributedCacheIdempotencyStore(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantIdempotency(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Mediant.Behaviors.Configuration.IdempotencyBehaviorOptions>? configure = null) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantIdempotencyCoordinator(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Mediant.Behaviors.Configuration.LoggingBehaviorOptions>? configure = null) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantOutbox(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Mediant.Behaviors.Outbox.OutboxProcessorOptions>? configure = null) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddMediantPerformanceMonitoring(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Mediant.Behaviors.Configuration.PerformanceBehaviorOptions>? configure = null) { }
@@ -232,6 +233,11 @@ namespace Mediant.Behaviors.DependencyInjection
 }
 namespace Mediant.Behaviors.Idempotency
 {
+    public sealed class DefaultIdempotentOperationCoordinator : Mediant.Behaviors.Idempotency.IIdempotentOperationCoordinator
+    {
+        public DefaultIdempotentOperationCoordinator(Mediant.Abstractions.IIdempotencyStore? store = null) { }
+        public System.Threading.Tasks.ValueTask<Mediant.Behaviors.Idempotency.IdempotentOperation<TResponse>> BeginAsync<TResponse>(string key, string? fingerprint = null, System.TimeSpan? lockWaitTimeout = default, System.Threading.CancellationToken cancellationToken = default) { }
+    }
     public sealed class DistributedCacheIdempotencyStore : Mediant.Abstractions.IIdempotencyStore
     {
         public DistributedCacheIdempotencyStore(Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Microsoft.Extensions.Options.IOptions<Mediant.Behaviors.Configuration.IdempotencyBehaviorOptions>? options = null) { }
@@ -239,6 +245,30 @@ namespace Mediant.Behaviors.Idempotency
         public System.Threading.Tasks.ValueTask<TResponse?> GetAsync<TResponse>(string idempotencyKey, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask RemoveAsync(string idempotencyKey, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SetAsync<TResponse>(string idempotencyKey, TResponse response, System.TimeSpan window, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public interface IIdempotentOperationCoordinator
+    {
+        System.Threading.Tasks.ValueTask<Mediant.Behaviors.Idempotency.IdempotentOperation<TResponse>> BeginAsync<TResponse>(string key, string? fingerprint = null, System.TimeSpan? lockWaitTimeout = default, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public sealed class IdempotencyEntry<TResponse>
+    {
+        public IdempotencyEntry() { }
+        public string? Fingerprint { get; init; }
+        public TResponse Response { get; init; }
+    }
+    public enum IdempotentOperationStatus
+    {
+        New = 0,
+        Replay = 1,
+        InFlight = 2,
+        FingerprintMismatch = 3,
+    }
+    public sealed class IdempotentOperation<TResponse> : System.IDisposable
+    {
+        public Mediant.Behaviors.Idempotency.IdempotentOperationStatus Status { get; }
+        public TResponse StoredResponse { get; }
+        public System.Threading.Tasks.ValueTask CompleteAsync(TResponse response, System.TimeSpan window, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Dispose() { }
     }
 }
 namespace Mediant.Behaviors.Outbox


### PR DESCRIPTION
## What

Closes #114. Adds a small public API so non-mediator entry points — concretely the Dfx HTTP `Idempotency-Key` middleware — can share the idempotency lifecycle and store with the `[Idempotent]` behavior instead of reinventing it:

- **`IIdempotentOperationCoordinator.BeginAsync<TResponse>(key, fingerprint?, lockWaitTimeout?, ct)`** — acquires the per-key lock, checks the store, returns a disposable `IdempotentOperation<TResponse>` handle.
- **`IdempotentOperationStatus`**: `New` (caller executes, then `CompleteAsync(response, window)`), `Replay` (serve `StoredResponse`), `InFlight` (lock not acquired within a finite `lockWaitTimeout` → 409-style), `FingerprintMismatch` (stored entry has a different payload fingerprint → 422-style; groundwork for #115).
- **`IdempotencyEntry<TResponse>`** envelope persists response + fingerprint through the existing `IIdempotencyStore` — works with `DistributedCacheIdempotencyStore` unchanged.
- **DI:** `AddMediantIdempotencyCoordinator()`; also auto-registered by `AddMediantDistributedCacheIdempotencyStore()`.
- `BoundedLockPool` (internal) gains `TryAcquireAsync(key, timeout, ct)`.

Design notes from the issue discussion are honored: the coordinator is a **DI singleton wrapping a single lock pool**; the fingerprint parameter and outcome enum are in the API from day one so #115 does not break the frozen surface; docs state the **process-local** serialization guarantee explicitly.

Failure semantics match the behavior: disposing without completing stores nothing, so a retry can run; a stored success is never deleted.

## Tests

9 new coordinator tests: new→complete→replay round-trip, dispose-without-complete leaves no trace, fingerprint match/mismatch/opt-in, zero-timeout InFlight, concurrent same-key serialization (one execution, all callers get the result), guard rails (complete on replay/after dispose), missing-store error. Public API baseline updated (additive only).

Full suite: 351 tests, 0 failures.

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG (Unreleased)
- [x] Added tests for new functionality