### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-07-04
 
 ### Added
 - **Buffered audit persistence** (#117) — opt-in `AddMediantAuditBuffering<TStore>()` decorates the registered `IAuditStore` with a process-wide bounded buffer: writes enqueue (backpressure when full — entries are never dropped by the buffer) and a background flusher batches them into the durable store (`AuditBufferOptions.BatchSize`, default 100, every `FlushInterval`, default 5s), cutting store round-trips for audit-heavy workloads by ~BatchSize×. Graceful shutdown flushes the buffer; a failed durable write re-enqueues the batch instead of losing it; `BufferedAuditStore.FlushAsync()` is the synchronous escape hatch for tests, and queries flush first (read-your-writes). **Durability trade-off (deliberate opt-in):** entries buffered but not yet flushed are lost on a hard process crash — without this call, audit writes stay synchronous as before.


### PR DESCRIPTION
## What

Release prep for **v1.1.0** (minor — all changes additive, no breaking API):

- `Directory.Build.props` version 1.0.1 → **1.1.0**
- CHANGELOG `[Unreleased]` → `[1.1.0] - 2026-07-04`

## Contents of v1.1.0

- #114 idempotency coordinator (`IIdempotentOperationCoordinator`) — PR #123
- #115 idempotency payload-fingerprint detection — PR #124
- #116 outbox lease-based multi-instance claiming — PR #125
- #117 opt-in buffered audit batching — PR #126
- #118 configurable performance hard ceiling — PR #122

After merge: tag `v1.1.0` triggers the Release workflow (pack → test → Trusted Publishing → GitHub Release).

## Checklist

- [x] All tests pass (`dotnet test`) — 364 tests green on main
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG
- [ ] Added tests for new functionality — N/A (version/changelog only)