### PR TITLE
fix(aspnetcore): bind positional-record queries on GET endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **GET endpoint binding for positional records** (#129) — a GET `[HttpEndpoint]` query declared as a positional record (`record GetOrdersQuery(string? Cursor = null, int Size = 50) : IQuery<...>`) previously failed at runtime with `MissingMethodException` (500) because binding required a parameterless constructor. `EndpointMapper` now binds positional records via their primary constructor — matching parameters to query/route values by name (case-insensitive), falling back to declared defaults for missing optionals, binding null for nullable/reference parameters, and returning a clear **400** (not 500) when a required value-type parameter is absent or invalid. Extra init/settable properties beyond the constructor are still bound. Init-property records and classes are unchanged.
+
 ## [1.1.0] - 2026-07-04
 
 ### Added

--- a/src/Mediant.AspNetCore/Mapping/EndpointMapper.cs
+++ b/src/Mediant.AspNetCore/Mapping/EndpointMapper.cs
@@ -173,6 +173,8 @@ public static class EndpointMapper
 
     private static readonly ConcurrentDictionary<Type, EndpointInvoker> InvokerCache = new();
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
+    private static readonly ConcurrentDictionary<Type, ConstructorInfo?> ParameterlessCtorCache = new();
+    private static readonly ConcurrentDictionary<Type, ConstructorInfo?> BindingCtorCache = new();
 
     private static Delegate CreateHandler(Type requestType, Type responseType, int successStatusCode)
     {
@@ -191,7 +193,7 @@ public static class EndpointMapper
                 {
                     return BindingErrorResult(bindingErrors);
                 }
-                request = boundRequest;
+                request = boundRequest!;
             }
             else
             {
@@ -269,7 +271,20 @@ public static class EndpointMapper
         => PropertyCache.GetOrAdd(requestType, static t =>
             t.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanWrite).ToArray());
 
-    private static (object Instance, List<string> Errors) BindFromQueryAndRoute(HttpContext context, Type requestType)
+    private static (object? Instance, List<string> Errors) BindFromQueryAndRoute(HttpContext context, Type requestType)
+    {
+        // Types with a public parameterless constructor (classes, init-property records) are bound
+        // by setting properties. Positional records expose only a parameterized primary
+        // constructor, so those are bound by matching constructor parameters to route/query values.
+        var parameterless = ParameterlessCtorCache.GetOrAdd(
+            requestType, static t => t.GetConstructor(Type.EmptyTypes));
+
+        return parameterless is not null
+            ? BindViaProperties(context, requestType)
+            : BindViaConstructor(context, requestType);
+    }
+
+    private static (object? Instance, List<string> Errors) BindViaProperties(HttpContext context, Type requestType)
     {
         var instance = Activator.CreateInstance(requestType)!;
         var properties = GetWritableProperties(requestType);
@@ -301,6 +316,114 @@ public static class EndpointMapper
 
         return (instance, errors);
     }
+
+    private static (object? Instance, List<string> Errors) BindViaConstructor(HttpContext context, Type requestType)
+    {
+        var errors = new List<string>();
+
+        // Positional records have a single public primary constructor. Guard against additional
+        // public constructors by preferring the greediest one (deterministic, matches the record
+        // shape); a copy constructor is protected and never appears here.
+        var ctor = BindingCtorCache.GetOrAdd(requestType, static t =>
+            t.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                .OrderByDescending(c => c.GetParameters().Length)
+                .FirstOrDefault());
+
+        if (ctor is null)
+        {
+            errors.Add($"Type '{requestType.Name}' has no public constructor to bind from the query string.");
+            return (null, errors);
+        }
+
+        var parameters = ctor.GetParameters();
+        var args = new object?[parameters.Length];
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            var param = parameters[i];
+            var name = param.Name!;
+
+            // Route values first, then query string — both collections match names
+            // case-insensitively.
+            string? value = context.Request.RouteValues.TryGetValue(name, out var routeVal)
+                ? routeVal?.ToString()
+                : context.Request.Query[name].FirstOrDefault();
+
+            if (value is not null)
+            {
+                var converted = ConvertValue(value, param.ParameterType);
+                if (converted is not null)
+                {
+                    args[i] = converted;
+                }
+                else
+                {
+                    errors.Add($"Parameter '{name}' has invalid value '{value}' for type '{param.ParameterType.Name}'.");
+                }
+            }
+            else if (param.HasDefaultValue)
+            {
+                args[i] = param.DefaultValue;
+            }
+            else if (IsNullableParameter(param))
+            {
+                // Reference types and Nullable<T> can hold null; leave it to the handler/validation.
+                args[i] = null;
+            }
+            else
+            {
+                // A required value-type parameter with no value would make ctor.Invoke throw
+                // (NRE/InvalidCast) → 500. Surface a clear 400 instead.
+                errors.Add($"Required parameter '{name}' is missing.");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            return (null, errors);
+        }
+
+        var instance = ctor.Invoke(args);
+
+        // A positional record may also declare extra init/settable properties beyond the primary
+        // constructor; bind those too so hybrid shapes work.
+        BindExtraProperties(context, instance, requestType, parameters);
+
+        return (instance, errors);
+    }
+
+    private static void BindExtraProperties(HttpContext context, object instance, Type requestType, ParameterInfo[] ctorParams)
+    {
+        var ctorParamNames = new HashSet<string>(ctorParams.Length, StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < ctorParams.Length; i++)
+        {
+            ctorParamNames.Add(ctorParams[i].Name!);
+        }
+
+        var properties = GetWritableProperties(requestType);
+        for (int i = 0; i < properties.Length; i++)
+        {
+            var prop = properties[i];
+            if (ctorParamNames.Contains(prop.Name)) continue;
+
+            string? value = context.Request.RouteValues.TryGetValue(prop.Name, out var routeVal)
+                ? routeVal?.ToString()
+                : context.Request.Query[prop.Name].FirstOrDefault();
+
+            if (value is not null)
+            {
+                var converted = ConvertValue(value, prop.PropertyType);
+                if (converted is not null)
+                {
+                    prop.SetValue(instance, converted);
+                }
+            }
+        }
+    }
+
+    private static bool IsNullableParameter(ParameterInfo parameter)
+        => !parameter.ParameterType.IsValueType
+           || Nullable.GetUnderlyingType(parameter.ParameterType) is not null;
 
     private static List<string> BindRouteParameters(HttpContext context, object request, Type requestType)
     {

--- a/tests/Mediant.IntegrationTests/HttpEndpointE2ETests.cs
+++ b/tests/Mediant.IntegrationTests/HttpEndpointE2ETests.cs
@@ -109,6 +109,37 @@ public class HttpEndpointE2ETests : IClassFixture<WebApplicationFactory<Program>
         userOrdersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
+    // === POSITIONAL-RECORD GET BINDING ===
+
+    [Fact]
+    public async Task ListOrders_PositionalRecord_BindsQueryValues()
+    {
+        var response = await _client.GetAsync("/api/orders?cursor=abc&size=25");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("abc").And.Contain("25");
+    }
+
+    [Fact]
+    public async Task ListOrders_PositionalRecord_MissingParams_UseConstructorDefaults()
+    {
+        var response = await _client.GetAsync("/api/orders");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        // Defaults: Cursor = null → "(none)", Size = 20
+        body.Should().Contain("(none)").And.Contain("20");
+    }
+
+    [Fact]
+    public async Task ListOrders_PositionalRecord_InvalidInt_Returns_400()
+    {
+        var response = await _client.GetAsync("/api/orders?size=not-a-number");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     // === GET ORDERS FOR USER ===
 
     [Fact]

--- a/tests/Mediant.Sample.ECommerce/Handlers/OrderHandlers.cs
+++ b/tests/Mediant.Sample.ECommerce/Handlers/OrderHandlers.cs
@@ -150,6 +150,13 @@ public sealed class GetOrdersForUserHandler : IQueryHandler<GetOrdersForUserQuer
     }
 }
 
+public sealed class ListOrdersHandler : IQueryHandler<ListOrdersQuery, Result<OrderPage>>
+{
+    public ValueTask<Result<OrderPage>> Handle(ListOrdersQuery request, CancellationToken cancellationToken)
+        // Echo the bound values so an E2E test can assert defaults and query values flowed through.
+        => new(new OrderPage(request.Cursor ?? "(none)", request.Size, Count: 0));
+}
+
 public sealed class SearchOrdersHandler : IStreamRequestHandler<SearchOrdersQuery, Order>
 {
     private readonly InMemoryOrderRepository _repo;

--- a/tests/Mediant.Sample.ECommerce/Queries/OrderQueries.cs
+++ b/tests/Mediant.Sample.ECommerce/Queries/OrderQueries.cs
@@ -19,6 +19,12 @@ public sealed record GetOrdersForUserQuery : IQuery<Result<List<Order>>>
     public string UserId { get; init; } = string.Empty;
 }
 
+// Positional record with optional parameters — exercises constructor-based GET binding.
+[HttpEndpoint("GET", "/api/orders", Summary = "List orders (paged)", Tags = new[] { "Orders" })]
+public sealed record ListOrdersQuery(string? Cursor = null, int Size = 20) : IQuery<Result<OrderPage>>;
+
+public sealed record OrderPage(string Cursor, int Size, int Count);
+
 // Streaming requests use CreateStream() directly, not HTTP endpoints
 public sealed record SearchOrdersQuery : IStreamRequest<Order>
 {

--- a/tests/Mediant.UnitTests/AspNetCore/EndpointBindingTests.cs
+++ b/tests/Mediant.UnitTests/AspNetCore/EndpointBindingTests.cs
@@ -1,0 +1,164 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Mediant.AspNetCore.Mapping;
+
+namespace Mediant.UnitTests.AspNetCore;
+
+/// <summary>
+/// GET query/route binding for both shapes: parameterless-ctor types (classes, init-property
+/// records) and positional records (parameterized primary constructor only).
+/// </summary>
+public class EndpointBindingTests
+{
+    // BindFromQueryAndRoute is private: (object? Instance, List<string> Errors)
+    private static readonly MethodInfo BindMethod =
+        typeof(EndpointMapper).GetMethod("BindFromQueryAndRoute", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static (object? Instance, IReadOnlyList<string> Errors) Bind(
+        Type requestType,
+        (string Key, string Value)[]? query = null,
+        (string Key, object Value)[]? route = null)
+    {
+        var context = new DefaultHttpContext();
+        if (query is not null)
+        {
+            context.Request.QueryString = new QueryString(
+                "?" + string.Join("&", query.Select(q => $"{Uri.EscapeDataString(q.Key)}={Uri.EscapeDataString(q.Value)}")));
+        }
+        if (route is not null)
+        {
+            var values = new RouteValueDictionary();
+            foreach (var (key, value) in route)
+            {
+                values[key] = value;
+            }
+            context.Request.RouteValues = values;
+        }
+
+        var tuple = BindMethod.Invoke(null, new object[] { context, requestType })!;
+        var instance = tuple.GetType().GetField("Item1")!.GetValue(tuple);
+        var errors = (IReadOnlyList<string>)((System.Collections.IEnumerable)tuple.GetType().GetField("Item2")!.GetValue(tuple)!)
+            .Cast<string>().ToList();
+        return (instance, errors);
+    }
+
+    // === Positional records ===
+
+    public sealed record GetOrdersQuery(string? Cursor = null, int Size = 50);
+
+    [Fact]
+    public void PositionalRecord_Binds_From_QueryString()
+    {
+        var (instance, errors) = Bind(typeof(GetOrdersQuery),
+            query: [("Cursor", "abc"), ("Size", "25")]);
+
+        errors.Should().BeEmpty();
+        var q = instance.Should().BeOfType<GetOrdersQuery>().Subject;
+        q.Cursor.Should().Be("abc");
+        q.Size.Should().Be(25);
+    }
+
+    [Fact]
+    public void PositionalRecord_Missing_Optionals_Fall_Back_To_Declared_Defaults()
+    {
+        var (instance, errors) = Bind(typeof(GetOrdersQuery));
+
+        errors.Should().BeEmpty();
+        var q = instance.Should().BeOfType<GetOrdersQuery>().Subject;
+        q.Cursor.Should().BeNull();
+        q.Size.Should().Be(50, "the constructor's declared default must be used when the value is absent");
+    }
+
+    [Fact]
+    public void PositionalRecord_Is_Case_Insensitive_On_Parameter_Names()
+    {
+        var (instance, errors) = Bind(typeof(GetOrdersQuery),
+            query: [("cursor", "x"), ("SIZE", "7")]);
+
+        errors.Should().BeEmpty();
+        var q = instance.Should().BeOfType<GetOrdersQuery>().Subject;
+        q.Cursor.Should().Be("x");
+        q.Size.Should().Be(7);
+    }
+
+    public sealed record GetByIdQuery(int Id);
+
+    [Fact]
+    public void PositionalRecord_Required_Value_Type_Missing_Reports_Error_Not_Throws()
+    {
+        var (instance, errors) = Bind(typeof(GetByIdQuery));
+
+        instance.Should().BeNull();
+        errors.Should().ContainSingle().Which.Should().Contain("Id").And.Contain("missing");
+    }
+
+    [Fact]
+    public void PositionalRecord_Invalid_Value_Reports_Error()
+    {
+        var (instance, errors) = Bind(typeof(GetByIdQuery), query: [("Id", "not-an-int")]);
+
+        instance.Should().BeNull();
+        errors.Should().ContainSingle().Which.Should().Contain("Id").And.Contain("invalid");
+    }
+
+    [Fact]
+    public void PositionalRecord_Binds_Route_Value()
+    {
+        var (instance, errors) = Bind(typeof(GetByIdQuery), route: [("Id", "42")]);
+
+        errors.Should().BeEmpty();
+        instance.Should().BeOfType<GetByIdQuery>().Subject.Id.Should().Be(42);
+    }
+
+    public sealed record HybridQuery(int Page)
+    {
+        public string? Filter { get; init; }
+    }
+
+    [Fact]
+    public void PositionalRecord_Also_Binds_Extra_Init_Properties()
+    {
+        var (instance, errors) = Bind(typeof(HybridQuery),
+            query: [("Page", "3"), ("Filter", "active")]);
+
+        errors.Should().BeEmpty();
+        var q = instance.Should().BeOfType<HybridQuery>().Subject;
+        q.Page.Should().Be(3);
+        q.Filter.Should().Be("active");
+    }
+
+    // === Regression: parameterless-ctor shapes still bind via properties ===
+
+    public sealed class InitQuery
+    {
+        public string? Name { get; set; }
+        public int Count { get; set; }
+    }
+
+    [Fact]
+    public void ParameterlessCtor_Class_Still_Binds_Via_Properties()
+    {
+        var (instance, errors) = Bind(typeof(InitQuery), query: [("Name", "bob"), ("Count", "9")]);
+
+        errors.Should().BeEmpty();
+        var q = instance.Should().BeOfType<InitQuery>().Subject;
+        q.Name.Should().Be("bob");
+        q.Count.Should().Be(9);
+    }
+
+    public sealed record InitRecord
+    {
+        public Guid Id { get; init; }
+    }
+
+    [Fact]
+    public void InitProperty_Record_Still_Binds()
+    {
+        var id = Guid.NewGuid();
+        var (instance, errors) = Bind(typeof(InitRecord), route: [("Id", id.ToString())]);
+
+        errors.Should().BeEmpty();
+        instance.Should().BeOfType<InitRecord>().Subject.Id.Should().Be(id);
+    }
+}


### PR DESCRIPTION
## What

Closes #129. A GET `[HttpEndpoint]` query declared as a **positional record** —
```csharp
[HttpEndpoint("GET", "/api/orders")]
public sealed record ListOrdersQuery(string? Cursor = null, int Size = 20) : IQuery<Result<OrderPage>>;
```
— failed at runtime with `MissingMethodException` (500) because `EndpointMapper.BindFromQueryAndRoute` used `Activator.CreateInstance`, which needs a parameterless constructor.

`BindFromQueryAndRoute` now branches on constructor shape:
- **Parameterless ctor** (classes, init-property records): unchanged property-binding path.
- **No parameterless ctor** (positional records): bind via the primary constructor — match each parameter to route/query values **by name, case-insensitively**; missing optionals fall back to their **declared defaults**; nullable/reference params bind null; a missing or invalid **required value-type** parameter returns a clear **400** (not a 500 from `ctor.Invoke`). Extra init/settable properties beyond the ctor are still bound (hybrid records).

## Acceptance criteria (from the issue)

- ✅ Positional record with defaults binds from the query string
- ✅ Missing optional parameters fall back to their declared defaults
- ✅ Clear 400 (not 500) when a required parameter is absent

## Tests

- **9 unit tests** (`EndpointBindingTests`) driving the binder with a `DefaultHttpContext`: positional binding, defaults, case-insensitivity, required-missing → error, invalid → error, route binding, hybrid extra-property binding, plus regressions for init-property records and classes.
- **3 real HTTP E2E tests** (`HttpEndpointE2ETests`) against a new positional-record endpoint in the ECommerce sample: query values bind, missing params use ctor defaults, invalid int → 400.

No public API change (all new binder methods are private). Full suite: 386 tests, 0 failures.

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG (Unreleased)
- [x] Added tests for new functionality