### PR TITLE
feat(caching): ship a default ICacheInvalidator so [InvalidatesCache] works

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Default cache invalidator** (#131) — `AddMediantCaching` now ships a working `ICacheInvalidator` (`DistributedCacheInvalidator`) so `[InvalidatesCache("prefix")]` actually evicts cached queries instead of silently no-op'ing (previously no implementation was registered → stale data with no error). Because `IDistributedCache` cannot enumerate keys, `CachingBehavior` records each written key under its `CacheKeyPrefix` in an `ICacheKeyRegistry` (default `DistributedCacheKeyRegistry`, same store) and the invalidator removes the registered keys; `InvalidateAllAsync` walks all known prefixes. Cross-process registry updates are best-effort — a rare orphaned key expires via its own TTL, bounding worst-case staleness to the cache duration. As a safety net, `CacheInvalidationBehavior` now logs a one-time warning when `[InvalidatesCache]` is present but no invalidator is registered.
+
 ### Fixed
 - **GET endpoint binding for positional records** (#129) — a GET `[HttpEndpoint]` query declared as a positional record (`record GetOrdersQuery(string? Cursor = null, int Size = 50) : IQuery<...>`) previously failed at runtime with `MissingMethodException` (500) because binding required a parameterless constructor. `EndpointMapper` now binds positional records via their primary constructor — matching parameters to query/route values by name (case-insensitive), falling back to declared defaults for missing optionals, binding null for nullable/reference parameters, and returning a clear **400** (not 500) when a required value-type parameter is absent or invalid. Extra init/settable properties beyond the constructor are still bound. Init-property records and classes are unchanged.
 

--- a/src/Mediant.Behaviors/Behaviors/CacheInvalidationBehavior.cs
+++ b/src/Mediant.Behaviors/Behaviors/CacheInvalidationBehavior.cs
@@ -23,6 +23,10 @@ public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBe
     private readonly ICacheInvalidator? _cacheInvalidator;
     private readonly ILogger<CacheInvalidationBehavior<TRequest, TResponse>> _logger;
 
+    // Ensures the "no invalidator registered" warning is emitted once per closed generic type
+    // instead of on every command execution.
+    private static int _missingInvalidatorWarned;
+
     public CacheInvalidationBehavior(
         ILogger<CacheInvalidationBehavior<TRequest, TResponse>> logger,
         ICacheInvalidator? cacheInvalidator = null)
@@ -33,8 +37,23 @@ public sealed class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBe
 
     public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        if (CachedAttributes.Length == 0 || _cacheInvalidator is null)
+        if (CachedAttributes.Length == 0)
         {
+            return await next().ConfigureAwait(false);
+        }
+
+        if (_cacheInvalidator is null)
+        {
+            // [InvalidatesCache] is present but nothing can act on it — a silent no-op would leave
+            // stale data with no signal, so warn once. Register an ICacheInvalidator (AddMediantCaching
+            // ships one by default) to enable invalidation.
+            if (Interlocked.Exchange(ref _missingInvalidatorWarned, 1) == 0)
+            {
+                _logger.LogWarning(
+                    "{RequestName} declares [InvalidatesCache] but no ICacheInvalidator is registered; cache invalidation is a no-op.",
+                    typeof(TRequest).Name);
+            }
+
             return await next().ConfigureAwait(false);
         }
 

--- a/src/Mediant.Behaviors/Behaviors/CachingBehavior.cs
+++ b/src/Mediant.Behaviors/Behaviors/CachingBehavior.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Mediant.Abstractions;
 using Mediant.Behaviors.Attributes;
+using Mediant.Behaviors.Caching;
 using Mediant.Behaviors.Configuration;
 
 namespace Mediant.Behaviors.Behaviors;
@@ -28,6 +29,7 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
     private readonly IDistributedCache? _cache;
     private readonly ILogger<CachingBehavior<TRequest, TResponse>> _logger;
     private readonly CachingBehaviorOptions _options;
+    private readonly ICacheKeyRegistry? _keyRegistry;
 
     // Cached type check — runs once per closed generic type, not per request
     private static readonly bool IsCommandType = typeof(TRequest).GetInterfaces()
@@ -59,11 +61,13 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
     public CachingBehavior(
         ILogger<CachingBehavior<TRequest, TResponse>> logger,
         IOptions<CachingBehaviorOptions> options,
-        IDistributedCache? cache = null)
+        IDistributedCache? cache = null,
+        ICacheKeyRegistry? keyRegistry = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _cache = cache;
+        _keyRegistry = keyRegistry;
     }
 
     public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
@@ -132,12 +136,21 @@ public sealed class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRe
             // Store in cache (null responses are valid)
             try
             {
+                var ttl = TimeSpan.FromSeconds(cacheableAttr.DurationSeconds);
                 var bytes = JsonSerializer.SerializeToUtf8Bytes(response, _options.SerializerOptions);
                 var cacheOptions = new DistributedCacheEntryOptions
                 {
-                    AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(cacheableAttr.DurationSeconds)
+                    AbsoluteExpirationRelativeToNow = ttl
                 };
                 await _cache.SetAsync(cacheKey, bytes, cacheOptions, cancellationToken).ConfigureAwait(false);
+
+                // Record the key under its prefix so [InvalidatesCache("prefix")] can find it —
+                // IDistributedCache cannot enumerate keys. Only prefixed cacheables participate in
+                // prefix invalidation, so a key without an explicit prefix needs no registration.
+                if (_keyRegistry is not null && cacheableAttr.CacheKeyPrefix is { } prefix)
+                {
+                    await _keyRegistry.RegisterAsync(prefix, cacheKey, ttl, cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Mediant.Behaviors/Caching/DistributedCacheInvalidator.cs
+++ b/src/Mediant.Behaviors/Caching/DistributedCacheInvalidator.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Mediant.Abstractions;
+
+namespace Mediant.Behaviors.Caching;
+
+/// <summary>
+/// Default <see cref="ICacheInvalidator"/> for the <see cref="IDistributedCache"/> caching path.
+/// Because a distributed cache cannot enumerate keys, it removes the keys an
+/// <see cref="ICacheKeyRegistry"/> recorded under each prefix (populated by <c>CachingBehavior</c>
+/// as it writes cache entries). Registered by <c>AddMediantCaching</c>, so <c>[InvalidatesCache]</c>
+/// works out of the box.
+/// </summary>
+public sealed class DistributedCacheInvalidator : ICacheInvalidator
+{
+    private readonly IDistributedCache? _cache;
+    private readonly ICacheKeyRegistry _registry;
+
+    /// <summary>Initializes a new instance of <see cref="DistributedCacheInvalidator"/>.</summary>
+    public DistributedCacheInvalidator(ICacheKeyRegistry registry, IDistributedCache? cache = null)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _cache = cache;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask InvalidateAsync(string keyPrefix, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyPrefix);
+        if (_cache is null)
+        {
+            return;
+        }
+
+        var keys = await _registry.GetKeysAsync(keyPrefix, cancellationToken).ConfigureAwait(false);
+        foreach (var key in keys)
+        {
+            await _cache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+        }
+
+        await _registry.ClearAsync(keyPrefix, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask InvalidateAllAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cache is null)
+        {
+            return;
+        }
+
+        var prefixes = await _registry.GetPrefixesAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var prefix in prefixes)
+        {
+            await InvalidateAsync(prefix, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Mediant.Behaviors/Caching/DistributedCacheKeyRegistry.cs
+++ b/src/Mediant.Behaviors/Caching/DistributedCacheKeyRegistry.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using Mediant.Behaviors.Behaviors;
+using Mediant.Behaviors.Configuration;
+
+namespace Mediant.Behaviors.Caching;
+
+/// <summary>
+/// Default <see cref="ICacheKeyRegistry"/> backed by the same <see cref="IDistributedCache"/> the
+/// caching pipeline uses. Per-prefix key sets and the set of known prefixes are stored as JSON.
+/// Read-modify-write is serialized per prefix with an in-process lock pool to keep intra-process
+/// updates correct; cross-process races are best-effort (documented on <see cref="ICacheKeyRegistry"/>).
+/// </summary>
+public sealed class DistributedCacheKeyRegistry : ICacheKeyRegistry
+{
+    private const string KeySetPrefix = "mediant:cache-registry:keys:";
+    private const string PrefixSetKey = "mediant:cache-registry:prefixes";
+
+    // The prefix registry must outlive the cache entries it tracks; keep it comfortably longer than
+    // any single entry TTL so it does not expire mid-window and lose invalidation coverage.
+    private static readonly TimeSpan MinRegistryTtl = TimeSpan.FromHours(1);
+
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.General)
+    {
+        PropertyNamingPolicy = null,
+    };
+
+    private readonly IDistributedCache? _cache;
+    private readonly BoundedLockPool _locks;
+
+    /// <summary>Initializes a new instance of <see cref="DistributedCacheKeyRegistry"/>.</summary>
+    public DistributedCacheKeyRegistry(IOptions<CachingBehaviorOptions> options, IDistributedCache? cache = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _cache = cache;
+        _locks = new BoundedLockPool(options.Value.MaxLockPoolSize);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask RegisterAsync(string prefix, string key, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(prefix);
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        if (_cache is null)
+        {
+            return;
+        }
+
+        var registryTtl = ttl > MinRegistryTtl ? ttl : MinRegistryTtl;
+
+        using var keyLock = await _locks.AcquireAsync(KeySetPrefix + prefix, cancellationToken).ConfigureAwait(false);
+
+        var keys = await ReadSetAsync(KeySetPrefix + prefix, cancellationToken).ConfigureAwait(false);
+        if (keys.Add(key))
+        {
+            await WriteSetAsync(KeySetPrefix + prefix, keys, registryTtl, cancellationToken).ConfigureAwait(false);
+        }
+
+        await RegisterPrefixAsync(prefix, registryTtl, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyCollection<string>> GetKeysAsync(string prefix, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(prefix);
+        if (_cache is null)
+        {
+            return [];
+        }
+
+        return await ReadSetAsync(KeySetPrefix + prefix, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyCollection<string>> GetPrefixesAsync(CancellationToken cancellationToken)
+    {
+        if (_cache is null)
+        {
+            return [];
+        }
+
+        return await ReadSetAsync(PrefixSetKey, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ClearAsync(string prefix, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(prefix);
+        if (_cache is null)
+        {
+            return;
+        }
+
+        using var keyLock = await _locks.AcquireAsync(KeySetPrefix + prefix, cancellationToken).ConfigureAwait(false);
+        await _cache.RemoveAsync(KeySetPrefix + prefix, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask RegisterPrefixAsync(string prefix, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        using var prefixLock = await _locks.AcquireAsync(PrefixSetKey, cancellationToken).ConfigureAwait(false);
+
+        var prefixes = await ReadSetAsync(PrefixSetKey, cancellationToken).ConfigureAwait(false);
+        if (prefixes.Add(prefix))
+        {
+            await WriteSetAsync(PrefixSetKey, prefixes, ttl, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask<HashSet<string>> ReadSetAsync(string storeKey, CancellationToken cancellationToken)
+    {
+        var bytes = await _cache!.GetAsync(storeKey, cancellationToken).ConfigureAwait(false);
+        if (bytes is null || bytes.Length == 0)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        var values = JsonSerializer.Deserialize<List<string>>(bytes, SerializerOptions);
+        return values is null ? new HashSet<string>(StringComparer.Ordinal) : new HashSet<string>(values, StringComparer.Ordinal);
+    }
+
+    private async ValueTask WriteSetAsync(string storeKey, HashSet<string> set, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(set, SerializerOptions);
+        var options = new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = ttl };
+        await _cache!.SetAsync(storeKey, bytes, options, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Mediant.Behaviors/Caching/ICacheKeyRegistry.cs
+++ b/src/Mediant.Behaviors/Caching/ICacheKeyRegistry.cs
@@ -1,0 +1,29 @@
+namespace Mediant.Behaviors.Caching;
+
+/// <summary>
+/// Tracks which cache keys were written under each <c>[Cacheable(CacheKeyPrefix = ...)]</c> prefix
+/// so a prefix-based <see cref="Mediant.Abstractions.ICacheInvalidator"/> can remove them —
+/// <see cref="Microsoft.Extensions.Caching.Distributed.IDistributedCache"/> cannot enumerate keys.
+/// <para>
+/// The default implementation stores the registry in the same distributed cache and is
+/// <b>best-effort</b> across processes: concurrent writers under one prefix can race the
+/// read-modify-write of the key set, so a rare orphaned key survives until its own TTL expires.
+/// This bounds worst-case staleness to the cache entry TTL. A HybridCache tag-based path (see the
+/// caching docs) makes invalidation exact and O(1).
+/// </para>
+/// </summary>
+public interface ICacheKeyRegistry
+{
+    /// <summary>Records that <paramref name="key"/> was written under <paramref name="prefix"/>.
+    /// <paramref name="ttl"/> keeps the registry entry alive at least as long as the cache entry.</summary>
+    ValueTask RegisterAsync(string prefix, string key, TimeSpan ttl, CancellationToken cancellationToken);
+
+    /// <summary>Returns the keys currently registered under <paramref name="prefix"/>.</summary>
+    ValueTask<IReadOnlyCollection<string>> GetKeysAsync(string prefix, CancellationToken cancellationToken);
+
+    /// <summary>Returns all prefixes that currently have registered keys.</summary>
+    ValueTask<IReadOnlyCollection<string>> GetPrefixesAsync(CancellationToken cancellationToken);
+
+    /// <summary>Removes the key set recorded for <paramref name="prefix"/>.</summary>
+    ValueTask ClearAsync(string prefix, CancellationToken cancellationToken);
+}

--- a/src/Mediant.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
+++ b/src/Mediant.Behaviors/DependencyInjection/BehaviorServiceCollectionExtensions.cs
@@ -241,6 +241,11 @@ public static class BehaviorServiceCollectionExtensions
             .Validate(o => o.DefaultDurationSeconds > 0, "DefaultDurationSeconds must be positive.")
             .Validate(o => o.MaxLockPoolSize > 0, "MaxLockPoolSize must be positive.");
 
+        // Ship a default key registry + invalidator so [InvalidatesCache] actually invalidates
+        // (IDistributedCache can't enumerate keys). TryAdd lets callers override either one.
+        services.TryAddSingleton<Caching.ICacheKeyRegistry, Caching.DistributedCacheKeyRegistry>();
+        services.TryAddSingleton<ICacheInvalidator, Caching.DistributedCacheInvalidator>();
+
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CacheInvalidationBehavior<,>));
         return services;

--- a/tests/Mediant.UnitTests/Behaviors/CacheInvalidationEndToEndTests.cs
+++ b/tests/Mediant.UnitTests/Behaviors/CacheInvalidationEndToEndTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mediant.Abstractions;
+using Mediant.Behaviors.Attributes;
+using Mediant.Behaviors.Behaviors;
+using Mediant.Behaviors.Caching;
+using Mediant.Behaviors.Configuration;
+using Mediant.Behaviors.DependencyInjection;
+using Mediant.DependencyInjection;
+using Mediant.Results;
+
+namespace Mediant.UnitTests.Behaviors;
+
+/// <summary>
+/// End-to-end coverage for the default cache invalidator shipped by <c>AddMediantCaching</c>
+/// (#131 — previously <c>[InvalidatesCache]</c> was a silent no-op because no
+/// <see cref="ICacheInvalidator"/> was registered).
+/// </summary>
+public class CacheInvalidationEndToEndTests
+{
+    [Fact]
+    public async Task InvalidatesCache_Command_Actually_Evicts_Cached_Query()
+    {
+        var executions = 0;
+        var sp = BuildProvider(() => executions++);
+        var sender = sp.GetRequiredService<ISender>();
+
+        // 1. Query executes the handler and caches under "rates:{hash}".
+        await sender.Send(new GetRatesQuery());
+        executions.Should().Be(1);
+
+        // 2. Served from cache — handler not re-run.
+        await sender.Send(new GetRatesQuery());
+        executions.Should().Be(1);
+
+        // 3. Command with [InvalidatesCache("rates")] must evict the entry.
+        await sender.Send(new UpdateRatesCommand());
+
+        // 4. Query re-executes the handler (cache was invalidated, not served stale).
+        await sender.Send(new GetRatesQuery());
+        executions.Should().Be(2, "[InvalidatesCache] must evict the cached entry so the query re-runs");
+    }
+
+    [Fact]
+    public async Task Default_Invalidator_Is_Registered_By_AddMediantCaching()
+    {
+        var sp = BuildProvider(() => { });
+        sp.GetService<ICacheInvalidator>().Should().BeOfType<DistributedCacheInvalidator>();
+        sp.GetService<ICacheKeyRegistry>().Should().BeOfType<DistributedCacheKeyRegistry>();
+    }
+
+    [Fact]
+    public async Task InvalidateAll_Evicts_Across_Prefixes()
+    {
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.Configure<CachingBehaviorOptions>(_ => { });
+        services.AddSingleton<ICacheKeyRegistry, DistributedCacheKeyRegistry>();
+        var sp = services.BuildServiceProvider();
+
+        var cache = sp.GetRequiredService<IDistributedCache>();
+        var registry = sp.GetRequiredService<ICacheKeyRegistry>();
+        await cache.SetStringAsync("a:1", "x");
+        await cache.SetStringAsync("b:1", "y");
+        await registry.RegisterAsync("a", "a:1", TimeSpan.FromMinutes(5), default);
+        await registry.RegisterAsync("b", "b:1", TimeSpan.FromMinutes(5), default);
+
+        var invalidator = new DistributedCacheInvalidator(registry, cache);
+        await invalidator.InvalidateAllAsync();
+
+        (await cache.GetAsync("a:1")).Should().BeNull();
+        (await cache.GetAsync("b:1")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CacheInvalidationBehavior_Warns_Once_When_No_Invalidator()
+    {
+        var logger = Substitute.For<ILogger<CacheInvalidationBehavior<UpdateRatesCommand, string>>>();
+        var behavior = new CacheInvalidationBehavior<UpdateRatesCommand, string>(logger, cacheInvalidator: null);
+
+        RequestHandlerDelegate<string> next = () => new ValueTask<string>("ok");
+
+        await behavior.Handle(new UpdateRatesCommand(), next, default);
+        await behavior.Handle(new UpdateRatesCommand(), next, default);
+
+        // Warned exactly once across the two invocations (static guard per closed generic type).
+        logger.ReceivedCalls()
+            .Count(c => c.GetArguments().OfType<LogLevel>().Contains(LogLevel.Warning))
+            .Should().Be(1);
+    }
+
+    private static ServiceProvider BuildProvider(Action onQueryExecute)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDistributedMemoryCache();
+        services.AddSingleton(onQueryExecute);
+        services.AddMediant(cfg => cfg.RegisterServicesFromAssembly(typeof(CacheInvalidationEndToEndTests).Assembly));
+        services.AddMediantCaching();
+        return services.BuildServiceProvider();
+    }
+}
+
+[Cacheable(300, CacheKeyPrefix = "rates")]
+public sealed record GetRatesQuery : IQuery<string>;
+
+public sealed class GetRatesQueryHandler : IQueryHandler<GetRatesQuery, string>
+{
+    private readonly Action _onExecute;
+    public GetRatesQueryHandler(Action onExecute) => _onExecute = onExecute;
+
+    public ValueTask<string> Handle(GetRatesQuery request, CancellationToken cancellationToken)
+    {
+        _onExecute();
+        return new ValueTask<string>("rate-data");
+    }
+}
+
+[InvalidatesCache("rates")]
+public sealed record UpdateRatesCommand : ICommand<string>;
+
+public sealed class UpdateRatesCommandHandler : ICommandHandler<UpdateRatesCommand, string>
+{
+    public ValueTask<string> Handle(UpdateRatesCommand request, CancellationToken cancellationToken)
+        => new("updated");
+}

--- a/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
+++ b/tests/Mediant.UnitTests/PublicApi/Mediant.Behaviors.approved.txt
@@ -117,7 +117,7 @@ namespace Mediant.Behaviors.Behaviors
     public sealed class CachingBehavior<TRequest, TResponse> : Mediant.Abstractions.IBehaviorOrder, Mediant.Abstractions.IPipelineBehavior<TRequest, TResponse>
         where TRequest : Mediant.Abstractions.IRequest<TResponse>
     {
-        public CachingBehavior(Microsoft.Extensions.Logging.ILogger<Mediant.Behaviors.Behaviors.CachingBehavior<TRequest, TResponse>> logger, Microsoft.Extensions.Options.IOptions<Mediant.Behaviors.Configuration.CachingBehaviorOptions> options, Microsoft.Extensions.Caching.Distributed.IDistributedCache? cache = null) { }
+        public CachingBehavior(Microsoft.Extensions.Logging.ILogger<Mediant.Behaviors.Behaviors.CachingBehavior<TRequest, TResponse>> logger, Microsoft.Extensions.Options.IOptions<Mediant.Behaviors.Configuration.CachingBehaviorOptions> options, Microsoft.Extensions.Caching.Distributed.IDistributedCache? cache = null, Mediant.Behaviors.Caching.ICacheKeyRegistry? keyRegistry = null) { }
         public int Order { get; }
         public System.Threading.Tasks.ValueTask<TResponse> Handle(TRequest request, Mediant.Abstractions.RequestHandlerDelegate<TResponse> next, System.Threading.CancellationToken cancellationToken) { }
     }
@@ -169,6 +169,30 @@ namespace Mediant.Behaviors.Behaviors
         public UnhandledExceptionBehavior(Microsoft.Extensions.Logging.ILogger<Mediant.Behaviors.Behaviors.UnhandledExceptionBehavior<TRequest, TResponse>> logger) { }
         public int Order { get; }
         public System.Threading.Tasks.ValueTask<TResponse> Handle(TRequest request, Mediant.Abstractions.RequestHandlerDelegate<TResponse> next, System.Threading.CancellationToken cancellationToken) { }
+    }
+}
+namespace Mediant.Behaviors.Caching
+{
+    public sealed class DistributedCacheInvalidator : Mediant.Abstractions.ICacheInvalidator
+    {
+        public DistributedCacheInvalidator(Mediant.Behaviors.Caching.ICacheKeyRegistry registry, Microsoft.Extensions.Caching.Distributed.IDistributedCache? cache = null) { }
+        public System.Threading.Tasks.ValueTask InvalidateAllAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask InvalidateAsync(string keyPrefix, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class DistributedCacheKeyRegistry : Mediant.Behaviors.Caching.ICacheKeyRegistry
+    {
+        public DistributedCacheKeyRegistry(Microsoft.Extensions.Options.IOptions<Mediant.Behaviors.Configuration.CachingBehaviorOptions> options, Microsoft.Extensions.Caching.Distributed.IDistributedCache? cache = null) { }
+        public System.Threading.Tasks.ValueTask ClearAsync(string prefix, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<string>> GetKeysAsync(string prefix, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<string>> GetPrefixesAsync(System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.ValueTask RegisterAsync(string prefix, string key, System.TimeSpan ttl, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public interface ICacheKeyRegistry
+    {
+        System.Threading.Tasks.ValueTask ClearAsync(string prefix, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<string>> GetKeysAsync(string prefix, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<string>> GetPrefixesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.ValueTask RegisterAsync(string prefix, string key, System.TimeSpan ttl, System.Threading.CancellationToken cancellationToken);
     }
 }
 namespace Mediant.Behaviors.Configuration


### PR DESCRIPTION
## What

Closes #131. `AddMediantCaching` registered `CacheInvalidationBehavior` but **no `ICacheInvalidator` implementation shipped anywhere in 1.1.0**, so `[InvalidatesCache("prefix")]` was a silent no-op — the worst cache failure mode: stale data with no error. The exact repro from the issue is now a passing test.

**Fix:**
- `AddMediantCaching` registers `DistributedCacheInvalidator` (default `ICacheInvalidator`) + `DistributedCacheKeyRegistry` (default `ICacheKeyRegistry`), both `TryAdd` so callers can override.
- Since `IDistributedCache` can't enumerate keys, `CachingBehavior` records each written key under its `CacheKeyPrefix` in the registry (only prefixed cacheables — the prefix IS the invalidation contract). The invalidator removes the registered keys and clears the set; `InvalidateAllAsync` walks all known prefixes.
- Cross-process registry updates are **best-effort** (per-prefix in-process lock; a rare orphaned key expires via its own TTL, bounding staleness to the cache duration). Documented on `ICacheKeyRegistry`; #130's HybridCache tag path will make this exact and O(1).
- **Loud, not silent:** `CacheInvalidationBehavior` logs a one-time warning when `[InvalidatesCache]` is seen with no invalidator registered.

## Tests

4 new tests (`CacheInvalidationEndToEndTests`) with a real `MemoryDistributedCache` + full DI:
- **The issue repro**: query caches → command with `[InvalidatesCache]` → next query re-executes the handler (not served stale).
- Default invalidator + registry are registered by `AddMediantCaching`.
- `InvalidateAllAsync` evicts across multiple prefixes.
- One-time warning when no invalidator.

Public API baseline updated (additive: two new types, one interface, one optional ctor param on `CachingBehavior`). Existing caching/invalidation unit tests unchanged and green. Full suite: 393 tests, 0 failures.

## Checklist

- [x] All tests pass (`dotnet test`)
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG (Unreleased)
- [x] Added tests for new functionality