### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-05
 
 ### Added
 - **HybridCache-backed query caching** (#130) — opt-in `AddMediantHybridCaching()` registers `HybridCachingBehavior<,>` + `HybridCacheInvalidator` on Microsoft's `HybridCache` (in-process **L1** + distributed **L2**, built-in stampede protection), an alternative to the `IDistributedCache`-only path (`AddMediantCaching`). `[Cacheable(CacheKeyPrefix = "p")]` tags entries with `p`, so `[InvalidatesCache("p")]` maps to an exact, **O(1)** `RemoveByTagAsync` — no key registry or prefix scan; `InvalidateAllAsync` clears a reserved all-entries tag. `Result`/`Result<T>` round-trip via their `[JsonConverter]` attributes. Use it *instead of* `AddMediantCaching` (also call `services.AddHybridCache()`). Adds a `Microsoft.Extensions.Caching.Hybrid` dependency to `Mediant.Behaviors`.


### PR DESCRIPTION
## What

Release prep for **v1.2.0** (minor — all additive, no breaking API):

- `Directory.Build.props` version 1.1.0 → **1.2.0**
- CHANGELOG `[Unreleased]` → `[1.2.0] - 2026-07-05`

## Contents of v1.2.0

- #130 optional HybridCache-backed query caching (L1+L2, O(1) tag invalidation) — PR #134
- #131 default `ICacheInvalidator` so `[InvalidatesCache]` works out of the box — PR #133
- #129 GET binding for positional-record queries (fix) — PR #132

After merge: tag `v1.2.0` triggers the Release workflow (pack → test → Trusted Publishing → GitHub Release).

## Checklist

- [x] All tests pass (`dotnet test`) — 387 tests green on main
- [x] No new warnings (`TreatWarningsAsErrors` is on)
- [x] Updated documentation if needed — CHANGELOG
- [ ] Added tests for new functionality — N/A (version/changelog only)