### PR TITLE
feat(efcore): ship AddMediantEfCoreUnitOfWork<TContext>() so [Transactional] works out of the box

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Built-in EF Core unit of work** (#137) — `AddMediantEfCoreUnitOfWork<TContext>()` registers `EfCoreUnitOfWork<TContext>` as the `IUnitOfWork`, so `[Transactional]` works against your DbContext out of the box — no hand-written unit of work needed for the direct-DbContext (no repository) setup. Because it resolves the same scoped context as your handlers and `EfOutboxStore<TContext>`, business writes and outbox messages commit atomically. `BeginTransactionAsync` is a no-op when a transaction is already open (execution-strategy retries), rollback **clears the change tracker** so rolled-back entities can never be re-flushed by a later `SaveChanges` on the same context, and on non-relational providers (EF InMemory in tests) transaction calls degrade to no-ops while `SaveChangesAsync` still flushes.
+
 ## [1.2.0] - 2026-07-05
 
 ### Added

--- a/docs/EF_CORE_GUIDE.md
+++ b/docs/EF_CORE_GUIDE.md
@@ -1,8 +1,33 @@
 # EF Core Integration Guide
 
-How to implement `IUnitOfWork` with Entity Framework Core for proper transaction management.
+How to wire `IUnitOfWork` with Entity Framework Core for proper transaction management.
 
-## Recommended IUnitOfWork Implementation
+## Recommended: the built-in unit of work
+
+`Mediant.EntityFrameworkCore` ships a ready-made implementation — no hand-written unit of work
+needed:
+
+```csharp
+services.AddDbContext<AppDbContext>(opts => opts.UseNpgsql(connectionString));
+services.AddMediantTransactions();                    // TransactionBehavior + PostCommitTaskQueue
+services.AddMediantEfCoreUnitOfWork<AppDbContext>();  // IUnitOfWork over your scoped context
+```
+
+`EfCoreUnitOfWork<TContext>` resolves the same scoped context your handlers write through (and
+that `EfOutboxStore<TContext>` tracks into), so `[Transactional]` commands commit business data
+and outbox messages atomically. It also:
+
+- skips `BeginTransaction` when a transaction is already open (execution-strategy retries,
+  caller-owned transactions),
+- **clears the change tracker on rollback**, so a failed handler's entities can never be
+  re-flushed by a later `SaveChanges` on the same context (e.g. a failure-audit write),
+- degrades transaction calls to no-ops on non-relational providers (EF InMemory), keeping
+  `[Transactional]` handlers testable.
+
+The rest of this guide shows the equivalent hand-written implementation, for cases where you need
+custom behavior (multiple contexts, ambient transactions, custom retry strategies).
+
+## Custom IUnitOfWork Implementation
 
 ```csharp
 public sealed class EfCoreUnitOfWork(DbContext context) : IUnitOfWork

--- a/src/Mediant.EntityFrameworkCore/EfCoreServiceCollectionExtensions.cs
+++ b/src/Mediant.EntityFrameworkCore/EfCoreServiceCollectionExtensions.cs
@@ -33,4 +33,19 @@ public static class EfCoreServiceCollectionExtensions
         services.TryAddScoped<IAuditStore, EfAuditStore<TContext>>();
         return services;
     }
+
+    /// <summary>
+    /// Registers <see cref="EfCoreUnitOfWork{TContext}"/> as the <see cref="IUnitOfWork"/> so
+    /// <c>[Transactional]</c> works against <typeparamref name="TContext"/> out of the box.
+    /// Register alongside <c>AddMediantTransactions()</c>. Because it resolves the same scoped
+    /// context as your handlers (and <see cref="EfOutboxStore{TContext}"/>), business writes and
+    /// outbox messages commit atomically.
+    /// </summary>
+    public static IServiceCollection AddMediantEfCoreUnitOfWork<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddScoped<IUnitOfWork, EfCoreUnitOfWork<TContext>>();
+        return services;
+    }
 }

--- a/src/Mediant.EntityFrameworkCore/EfCoreUnitOfWork.cs
+++ b/src/Mediant.EntityFrameworkCore/EfCoreUnitOfWork.cs
@@ -1,0 +1,113 @@
+using Microsoft.EntityFrameworkCore;
+using Mediant.Abstractions;
+
+namespace Mediant.EntityFrameworkCore;
+
+/// <summary>
+/// <see cref="IUnitOfWork"/> backed by an EF Core <typeparamref name="TContext"/>, wiring
+/// <c>[Transactional]</c> to <c>Database.BeginTransaction/Commit/Rollback</c> on the same scoped
+/// context your handlers write through — so handler changes, tracked outbox messages and the
+/// commit are atomic without any repository layer.
+/// <para>
+/// <see cref="BeginTransactionAsync"/> is a no-op when a transaction is already open (e.g. an
+/// execution-strategy retry re-entering the behavior), and <see cref="RollbackAsync"/> clears the
+/// change tracker so entities from the rolled-back handler can never be flushed by a later
+/// <c>SaveChanges</c> on the same context (such as an audit write after a failure).
+/// </para>
+/// <para>
+/// On non-relational providers (e.g. EF InMemory in tests) transaction operations are no-ops;
+/// <see cref="SaveChangesAsync"/> still flushes, so <c>[Transactional]</c> handlers stay testable.
+/// </para>
+/// </summary>
+public sealed class EfCoreUnitOfWork<TContext> : IUnitOfWork
+    where TContext : DbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>Initializes a new instance of <see cref="EfCoreUnitOfWork{TContext}"/>.</summary>
+    public EfCoreUnitOfWork(TContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask BeginTransactionAsync(CancellationToken cancellationToken)
+    {
+        if (!_context.Database.IsRelational())
+        {
+            return;
+        }
+
+        // Already inside a transaction (execution-strategy retry, or one the caller opened) —
+        // participate instead of double-beginning.
+        if (_context.Database.CurrentTransaction is not null)
+        {
+            return;
+        }
+
+        await _context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask SaveChangesAsync(CancellationToken cancellationToken)
+        => await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async ValueTask CommitAsync(CancellationToken cancellationToken)
+    {
+        var transaction = _context.Database.CurrentTransaction;
+        if (transaction is null)
+        {
+            return;
+        }
+
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask RollbackAsync(CancellationToken cancellationToken)
+    {
+        var transaction = _context.Database.CurrentTransaction;
+
+        try
+        {
+            if (transaction is not null)
+            {
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            // Rollback does not detach tracked entities; clear them so a later SaveChanges on
+            // this context (e.g. a failure-audit write) cannot flush the rolled-back handler's
+            // Added/Modified entities outside the transaction.
+            _context.ChangeTracker.Clear();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask CreateSavepointAsync(string name, CancellationToken cancellationToken)
+    {
+        var transaction = _context.Database.CurrentTransaction;
+        if (transaction is null)
+        {
+            return;
+        }
+
+        await transaction.CreateSavepointAsync(name, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask RollbackToSavepointAsync(string name, CancellationToken cancellationToken)
+    {
+        var transaction = _context.Database.CurrentTransaction;
+        if (transaction is null)
+        {
+            return;
+        }
+
+        await transaction.RollbackToSavepointAsync(name, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/tests/Mediant.EntityFrameworkCore.Tests/EfCoreUnitOfWorkTests.cs
+++ b/tests/Mediant.EntityFrameworkCore.Tests/EfCoreUnitOfWorkTests.cs
@@ -1,0 +1,318 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Mediant.Abstractions;
+using Mediant.Behaviors.Attributes;
+using Mediant.Behaviors.DependencyInjection;
+using Mediant.DependencyInjection;
+using Mediant.EntityFrameworkCore;
+
+namespace Mediant.EntityFrameworkCore.Tests;
+
+public sealed class UowDbContext : DbContext
+{
+    public UowDbContext(DbContextOptions<UowDbContext> options) : base(options) { }
+
+    public DbSet<UowOrder> Orders => Set<UowOrder>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<UowOrder>().HasKey(o => o.Id);
+        modelBuilder.ConfigureMediantOutbox();
+        modelBuilder.ConfigureMediantAudit();
+    }
+}
+
+public sealed class UowOrder
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public sealed class EfCoreUnitOfWorkTests : IDisposable
+{
+    // A single open in-memory SQLite connection keeps the database alive and gives every
+    // context real relational transactions.
+    private readonly SqliteConnection _connection;
+
+    public EfCoreUnitOfWorkTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        using var context = NewContext();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private UowDbContext NewContext()
+        => new(new DbContextOptionsBuilder<UowDbContext>().UseSqlite(_connection).Options);
+
+    [Fact]
+    public async Task Commit_Persists_Writes_Made_Inside_The_Transaction()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.BeginTransactionAsync(default);
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "committed" });
+        await uow.SaveChangesAsync(default);
+        await uow.CommitAsync(default);
+
+        using var verify = NewContext();
+        (await verify.Orders.CountAsync()).Should().Be(1);
+        context.Database.CurrentTransaction.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Rollback_Discards_Writes_And_Clears_The_ChangeTracker()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.BeginTransactionAsync(default);
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "doomed" });
+        await uow.SaveChangesAsync(default);
+        await uow.RollbackAsync(default);
+
+        // Nothing hit the database…
+        using var verify = NewContext();
+        (await verify.Orders.CountAsync()).Should().Be(0);
+
+        // …and the tracker is empty, so a later SaveChanges (e.g. a failure-audit write on the
+        // same context) can never re-flush the rolled-back entities.
+        context.ChangeTracker.Entries().Should().BeEmpty();
+        await context.SaveChangesAsync();
+        (await verify.Orders.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Rollback_Clears_Tracked_Entities_Even_When_SaveChanges_Was_Never_Called()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.BeginTransactionAsync(default);
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "never-saved" });
+        await uow.RollbackAsync(default);
+
+        context.ChangeTracker.Entries().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BeginTransaction_Is_A_NoOp_When_A_Transaction_Is_Already_Open()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.BeginTransactionAsync(default);
+        var first = context.Database.CurrentTransaction;
+
+        // Second Begin (execution-strategy retry / re-entry) must not throw or replace it.
+        await uow.BeginTransactionAsync(default);
+        context.Database.CurrentTransaction.Should().BeSameAs(first);
+
+        await uow.RollbackAsync(default);
+    }
+
+    [Fact]
+    public async Task Commit_And_Rollback_Without_A_Transaction_Are_NoOps()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.Invoking(u => u.CommitAsync(default).AsTask()).Should().NotThrowAsync();
+        await uow.Invoking(u => u.RollbackAsync(default).AsTask()).Should().NotThrowAsync();
+        await uow.Invoking(u => u.CreateSavepointAsync("sp", default).AsTask()).Should().NotThrowAsync();
+        await uow.Invoking(u => u.RollbackToSavepointAsync("sp", default).AsTask()).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RollbackToSavepoint_Unwinds_Only_The_Work_After_The_Savepoint()
+    {
+        using var context = NewContext();
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        await uow.BeginTransactionAsync(default);
+
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "outer" });
+        await uow.SaveChangesAsync(default);
+
+        await uow.CreateSavepointAsync("inner", default);
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "inner" });
+        await uow.SaveChangesAsync(default);
+
+        await uow.RollbackToSavepointAsync("inner", default);
+        await uow.CommitAsync(default);
+
+        using var verify = NewContext();
+        var names = await verify.Orders.Select(o => o.Name).ToListAsync();
+        names.Should().ContainSingle().Which.Should().Be("outer");
+    }
+
+    [Fact]
+    public async Task NonRelational_Provider_Skips_Transactions_But_Still_Flushes()
+    {
+        using var context = new UowDbContext(new DbContextOptionsBuilder<UowDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+        var uow = new EfCoreUnitOfWork<UowDbContext>(context);
+
+        // InMemory throws on BeginTransaction; the UoW must degrade to no-op transactions so
+        // [Transactional] handlers stay testable.
+        await uow.BeginTransactionAsync(default);
+        context.Orders.Add(new UowOrder { Id = Guid.NewGuid(), Name = "in-memory" });
+        await uow.SaveChangesAsync(default);
+        await uow.CommitAsync(default);
+
+        (await context.Orders.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public void Registration_Is_Scoped_And_Respects_An_Existing_IUnitOfWork()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<UowDbContext>(o => o.UseSqlite(_connection));
+        services.AddMediantEfCoreUnitOfWork<UowDbContext>();
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IUnitOfWork));
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        descriptor.ImplementationType.Should().Be<EfCoreUnitOfWork<UowDbContext>>();
+
+        // TryAdd semantics: a custom IUnitOfWork registered first wins.
+        var custom = new ServiceCollection();
+        custom.AddScoped<IUnitOfWork, FakeUnitOfWork>();
+        custom.AddMediantEfCoreUnitOfWork<UowDbContext>();
+        custom.Single(d => d.ServiceType == typeof(IUnitOfWork))
+            .ImplementationType.Should().Be<FakeUnitOfWork>();
+    }
+
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        public ValueTask BeginTransactionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask CommitAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask RollbackAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask CreateSavepointAsync(string name, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask RollbackToSavepointAsync(string name, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>
+/// End-to-end: the real mediator pipeline with <c>AddMediantTransactions()</c> +
+/// <c>AddMediantEfCoreUnitOfWork</c> against SQLite — the direct-DbContext (no repository)
+/// clean-architecture setup the package is meant to serve out of the box.
+/// </summary>
+public sealed class EfCoreUnitOfWorkPipelineTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+
+    public EfCoreUnitOfWorkPipelineTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var context = new UowDbContext(
+            new DbContextOptionsBuilder<UowDbContext>().UseSqlite(_connection).Options))
+        {
+            context.Database.EnsureCreated();
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<UowDbContext>(o => o.UseSqlite(_connection));
+        services.AddMediant(cfg => cfg.RegisterServicesFromAssembly(typeof(EfCoreUnitOfWorkPipelineTests).Assembly));
+        services.AddMediantTransactions();
+        services.AddMediantEfCoreUnitOfWork<UowDbContext>();
+        // EF outbox store BEFORE AddMediantOutbox so the durable store wins the TryAdd.
+        services.AddMediantEfCoreOutboxStore<UowDbContext>();
+        services.AddMediantOutbox();
+        _provider = services.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task Transactional_Command_Commits_Business_Write_And_Outbox_Message_Atomically()
+    {
+        using var scope = _provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // The handler writes through the context and enqueues an outbox message but never calls
+        // SaveChanges — TransactionBehavior's flush + commit must persist both.
+        await mediator.Send(new CreateUowOrderCommand("atomic", Fail: false));
+
+        using var verifyScope = _provider.CreateScope();
+        var db = verifyScope.ServiceProvider.GetRequiredService<UowDbContext>();
+        (await db.Orders.CountAsync()).Should().Be(1);
+        (await db.Set<OutboxMessage>().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Failing_Transactional_Command_Persists_Nothing_And_Leaves_A_Clean_Tracker()
+    {
+        using var scope = _provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Invoking(m => m.Send(new CreateUowOrderCommand("doomed", Fail: true)).AsTask())
+            .Should().ThrowAsync<InvalidOperationException>().WithMessage("handler failed");
+
+        using (var verifyScope = _provider.CreateScope())
+        {
+            var db = verifyScope.ServiceProvider.GetRequiredService<UowDbContext>();
+            (await db.Orders.CountAsync()).Should().Be(0);
+            (await db.Set<OutboxMessage>().CountAsync()).Should().Be(0);
+        }
+
+        // The scope's context must not be left holding the rolled-back entities: a later
+        // SaveChanges on the same scoped context (audit, another command) must not resurrect them.
+        var scopedDb = scope.ServiceProvider.GetRequiredService<UowDbContext>();
+        scopedDb.ChangeTracker.Entries().Should().BeEmpty();
+        await scopedDb.SaveChangesAsync();
+
+        using var finalScope = _provider.CreateScope();
+        var finalDb = finalScope.ServiceProvider.GetRequiredService<UowDbContext>();
+        (await finalDb.Orders.CountAsync()).Should().Be(0);
+    }
+}
+
+[Transactional]
+public sealed record CreateUowOrderCommand(string Name, bool Fail) : ICommand<Guid>;
+
+internal sealed class CreateUowOrderHandler : IRequestHandler<CreateUowOrderCommand, Guid>
+{
+    private readonly UowDbContext _db;
+    private readonly IOutbox _outbox;
+
+    public CreateUowOrderHandler(UowDbContext db, IOutbox outbox)
+    {
+        _db = db;
+        _outbox = outbox;
+    }
+
+    public async ValueTask<Guid> Handle(CreateUowOrderCommand request, CancellationToken cancellationToken)
+    {
+        var order = new UowOrder { Id = Guid.NewGuid(), Name = request.Name };
+        _db.Orders.Add(order);
+        await _outbox.EnqueueAsync(new UowOrderCreated(order.Id), cancellationToken);
+
+        if (request.Fail)
+        {
+            throw new InvalidOperationException("handler failed");
+        }
+
+        // Intentionally no SaveChanges — TransactionBehavior's safety net owns the flush.
+        return order.Id;
+    }
+}
+
+public sealed record UowOrderCreated(Guid OrderId) : INotification;
+
+internal sealed class UowOrderCreatedHandler : INotificationHandler<UowOrderCreated>
+{
+    public ValueTask Handle(UowOrderCreated notification, CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
+}


### PR DESCRIPTION
Closes #137

## What

`Mediant.EntityFrameworkCore` now ships a first-class `IUnitOfWork`:

- **`EfCoreUnitOfWork<TContext>`** — wires `[Transactional]` to `Database.BeginTransaction/Commit/Rollback` on the same scoped context handlers write through.
- **`AddMediantEfCoreUnitOfWork<TContext>()`** — `TryAddScoped` registration, consistent with the existing outbox/audit store extensions.

Design points (per the issue):

- `BeginTransactionAsync` is a no-op when a transaction is already open (execution-strategy retry / caller-owned transaction).
- `RollbackAsync` **clears the change tracker** — rollback does not detach tracked entities, so without this a later `SaveChanges` on the same context (e.g. a failure-audit write, see #138) would re-flush the rolled-back handler's entities outside any transaction.
- Non-relational providers (EF InMemory in tests) degrade transaction calls to no-ops while `SaveChangesAsync` still flushes, keeping `[Transactional]` handlers testable — same approach as `EfOutboxStore`'s `IsRelational()` fallback.
- Savepoint members delegate to the current transaction (no-op when none), so the interface is fully implemented.

## Tests (10 new, SQLite for real relational transactions)

Unit level: commit persists; rollback discards writes **and** leaves an empty tracker (including the never-saved case, plus proof a follow-up `SaveChanges` resurrects nothing); double-begin no-op; commit/rollback/savepoints without a transaction are no-ops; savepoint rollback unwinds only inner work; InMemory degradation; DI lifetime + TryAdd semantics.

End to end through the real pipeline (`AddMediantTransactions` + `AddMediantEfCoreUnitOfWork` + `AddMediantEfCoreOutboxStore`): a `[Transactional]` command whose handler never calls `SaveChanges` commits business row + outbox message atomically; a failing handler persists nothing and leaves the scoped context's tracker clean.

Full solution suite: **394 passed, 0 failed** (baseline 384 — no as-is behavior touched; both extensions and stores keep their existing `TryAdd` semantics).

## Docs

- `EF_CORE_GUIDE.md`: leads with the built-in registration; the hand-written sample stays as an "advanced/custom" reference (its own bugs are tracked in #140).
- `CHANGELOG.md`: `[Unreleased]` entry.