### PR TITLE
fix(efcore): rolled-back entities can no longer be re-flushed by a failure-audit write on a shared context

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Rolled-back entities can no longer be re-flushed by a failure-audit write on a shared context** (#138) — when a `[Transactional]` + audited command failed and business data shared one scoped `DbContext` with the unbuffered `EfAuditStore`, the failure-audit `SaveChangesAsync` re-flushed the rolled-back handler entities outside any transaction (rollback does not detach tracked entities), leaking half-done data. The built-in `EfCoreUnitOfWork<TContext>` clears the change tracker on rollback; the `EF_CORE_GUIDE.md` custom unit-of-work template now marks `ChangeTracker.Clear()` as required in `RollbackAsync`, and `EfAuditStore` documents the shared-context caveat. Covered by end-to-end regression tests (failure audit persists, business rows do not, and a later command in the same scope stays uncontaminated).
+
 ### Added
 - **Built-in EF Core unit of work** (#137) — `AddMediantEfCoreUnitOfWork<TContext>()` registers `EfCoreUnitOfWork<TContext>` as the `IUnitOfWork`, so `[Transactional]` works against your DbContext out of the box — no hand-written unit of work needed for the direct-DbContext (no repository) setup. Because it resolves the same scoped context as your handlers and `EfOutboxStore<TContext>`, business writes and outbox messages commit atomically. `BeginTransactionAsync` is a no-op when a transaction is already open (execution-strategy retries), rollback **clears the change tracker** so rolled-back entities can never be re-flushed by a later `SaveChanges` on the same context, and on non-relational providers (EF InMemory in tests) transaction calls degrade to no-ops while `SaveChangesAsync` still flushes.
 

--- a/docs/EF_CORE_GUIDE.md
+++ b/docs/EF_CORE_GUIDE.md
@@ -54,8 +54,19 @@ public sealed class EfCoreUnitOfWork(DbContext context) : IUnitOfWork
 
     public async ValueTask RollbackAsync(CancellationToken cancellationToken)
     {
-        if (context.Database.CurrentTransaction is null) return;
-        await context.Database.CurrentTransaction.RollbackAsync(cancellationToken);
+        try
+        {
+            if (context.Database.CurrentTransaction is null) return;
+            await context.Database.CurrentTransaction.RollbackAsync(cancellationToken);
+        }
+        finally
+        {
+            // REQUIRED: rollback does not detach tracked entities. Without this, a later
+            // SaveChanges on the same scoped context (e.g. EfAuditStore persisting the
+            // failure audit entry) re-flushes the rolled-back entities OUTSIDE any
+            // transaction — leaking half-done data from a failed command.
+            context.ChangeTracker.Clear();
+        }
     }
 
     public ValueTask CreateSavepointAsync(string name, CancellationToken cancellationToken)

--- a/src/Mediant.EntityFrameworkCore/EfAuditStore.cs
+++ b/src/Mediant.EntityFrameworkCore/EfAuditStore.cs
@@ -7,6 +7,15 @@ namespace Mediant.EntityFrameworkCore;
 /// <summary>
 /// Durable <see cref="IAuditStore"/> backed by an EF Core <typeparamref name="TContext"/> with a
 /// mapped <see cref="AuditEntry"/> entity (see <c>ModelBuilder.ConfigureMediantAudit()</c>).
+/// <para>
+/// <b>Shared-context caveat:</b> <see cref="SaveAsync"/> calls <c>SaveChangesAsync</c>, which
+/// flushes <i>everything</i> tracked by <typeparamref name="TContext"/> — including pending
+/// entities left behind by a failed handler. When business data and this store share one scoped
+/// context, the <see cref="IUnitOfWork"/> must clear the change tracker on rollback (the built-in
+/// <see cref="EfCoreUnitOfWork{TContext}"/> does) so a failure-audit write cannot persist
+/// rolled-back business entities. Alternatively, decorate with <c>AddMediantAuditBuffering</c>,
+/// which flushes from a fresh scope.
+/// </para>
 /// </summary>
 public sealed class EfAuditStore<TContext> : IAuditStore
     where TContext : DbContext

--- a/tests/Mediant.EntityFrameworkCore.Tests/EfAuditRollbackRegressionTests.cs
+++ b/tests/Mediant.EntityFrameworkCore.Tests/EfAuditRollbackRegressionTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Mediant.Abstractions;
+using Mediant.Audit;
+using Mediant.Behaviors.Attributes;
+using Mediant.Behaviors.DependencyInjection;
+using Mediant.DependencyInjection;
+using Mediant.EntityFrameworkCore;
+
+namespace Mediant.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Regression for the shared-context rollback + audit hazard (#138): a failed
+/// <c>[Transactional]</c> + audited command must leave NO business rows behind while still
+/// persisting the failure audit entry. Before the change-tracker-clearing rollback in
+/// <see cref="EfCoreUnitOfWork{TContext}"/>, the unbuffered <see cref="EfAuditStore{TContext}"/>'s
+/// <c>SaveChangesAsync</c> on the same scoped context re-flushed the rolled-back handler
+/// entities outside any transaction.
+/// </summary>
+public sealed class EfAuditRollbackRegressionTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+
+    public EfAuditRollbackRegressionTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var context = new UowDbContext(
+            new DbContextOptionsBuilder<UowDbContext>().UseSqlite(_connection).Options))
+        {
+            context.Database.EnsureCreated();
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<UowDbContext>(o => o.UseSqlite(_connection));
+        services.AddMediant(cfg => cfg.RegisterServicesFromAssembly(typeof(EfAuditRollbackRegressionTests).Assembly));
+        // The exact setup from the issue: business data and the UNBUFFERED audit store share one
+        // scoped context. EF stores registered before the behaviors so they win the TryAdd.
+        services.AddMediantEfCoreAuditStore<UowDbContext>();
+        services.AddMediantEfCoreUnitOfWork<UowDbContext>();
+        services.AddMediantAuditing();
+        services.AddMediantTransactions();
+        _provider = services.BuildServiceProvider();
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task Failed_Transactional_Audited_Command_Persists_The_Failure_Audit_But_No_Business_Rows()
+    {
+        using var scope = _provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Invoking(m => m.Send(new AuditedCreateOrderCommand("doomed", Fail: true)).AsTask())
+            .Should().ThrowAsync<InvalidOperationException>().WithMessage("audited handler failed");
+
+        using var verifyScope = _provider.CreateScope();
+        var db = verifyScope.ServiceProvider.GetRequiredService<UowDbContext>();
+
+        // The core of #138: the failure-audit SaveChanges on the shared context must NOT
+        // resurrect the rolled-back handler entities.
+        (await db.Orders.CountAsync()).Should().Be(0);
+
+        var audit = await db.Set<AuditEntry>().SingleAsync();
+        audit.IsSuccess.Should().BeFalse();
+        audit.ErrorMessage.Should().Be("audited handler failed");
+        audit.RequestType.Should().Contain(nameof(AuditedCreateOrderCommand));
+    }
+
+    [Fact]
+    public async Task Successful_Transactional_Audited_Command_Persists_Business_Row_And_Success_Audit()
+    {
+        using var scope = _provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Send(new AuditedCreateOrderCommand("ok", Fail: false));
+
+        using var verifyScope = _provider.CreateScope();
+        var db = verifyScope.ServiceProvider.GetRequiredService<UowDbContext>();
+        (await db.Orders.CountAsync()).Should().Be(1);
+
+        var audit = await db.Set<AuditEntry>().SingleAsync();
+        audit.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Failed_Command_Then_Second_Command_In_The_Same_Scope_Stays_Uncontaminated()
+    {
+        // A rolled-back command must not leak tracked entities into a later command that
+        // commits on the same scoped context (same DI scope = same DbContext instance).
+        using var scope = _provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Invoking(m => m.Send(new AuditedCreateOrderCommand("doomed", Fail: true)).AsTask())
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        await mediator.Send(new AuditedCreateOrderCommand("survivor", Fail: false));
+
+        using var verifyScope = _provider.CreateScope();
+        var db = verifyScope.ServiceProvider.GetRequiredService<UowDbContext>();
+        var names = await db.Orders.Select(o => o.Name).ToListAsync();
+        names.Should().ContainSingle().Which.Should().Be("survivor");
+    }
+}
+
+[Transactional]
+[Auditable]
+public sealed record AuditedCreateOrderCommand(string Name, bool Fail) : ICommand<Guid>;
+
+internal sealed class AuditedCreateOrderHandler : IRequestHandler<AuditedCreateOrderCommand, Guid>
+{
+    private readonly UowDbContext _db;
+
+    public AuditedCreateOrderHandler(UowDbContext db) => _db = db;
+
+    public ValueTask<Guid> Handle(AuditedCreateOrderCommand request, CancellationToken cancellationToken)
+    {
+        var order = new UowOrder { Id = Guid.NewGuid(), Name = request.Name };
+        _db.Orders.Add(order);
+
+        if (request.Fail)
+        {
+            throw new InvalidOperationException("audited handler failed");
+        }
+
+        return ValueTask.FromResult(order.Id);
+    }
+}


### PR DESCRIPTION
Closes #138

## What

The hazard: rollback does not detach tracked entities, so when a `[Transactional]` + audited command failed, the unbuffered `EfAuditStore`'s failure-audit `SaveChangesAsync` on the same scoped context re-flushed the rolled-back handler entities **outside any transaction** — leaking half-done data.

The core fix (change-tracker-clearing rollback in `EfCoreUnitOfWork<TContext>`) shipped with #142. This PR completes #138:

- **End-to-end regression tests** (3, SQLite, real pipeline with `AddMediantAuditing` + `AddMediantTransactions` + `AddMediantEfCoreAuditStore`/`UnitOfWork`, exactly the shared-context setup from the issue):
  - failed `[Transactional]` + `[Auditable]` command → failure audit entry persisted (`IsSuccess = false`, error message intact), **zero** business rows;
  - successful command → business row + success audit;
  - failed command followed by a committing command in the same DI scope → only the second command's data lands (no cross-command contamination).
- **`EF_CORE_GUIDE.md`**: the custom unit-of-work template's `RollbackAsync` now clears the tracker in a `finally`, marked REQUIRED with an explanation of why.
- **`EfAuditStore`** XML docs: shared-context caveat documented (tracker-clearing UoW or `AddMediantAuditBuffering` as the safe alternatives).

## Verification

Mutation-checked: temporarily commenting out `ChangeTracker.Clear()` in `EfCoreUnitOfWork.RollbackAsync` makes both failure-path tests fail with exactly the resurrected rows the issue describes; restoring it turns them green.

Full solution suite: **397 passed, 0 failed** (394 baseline after #142 + 3 new). No production code paths changed in this PR beyond XML docs — as-is behavior untouched.