### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-07-12
 
 ### Fixed
 - **EF Core guide's custom unit-of-work sample now resolves** (#140) — the `EF_CORE_GUIDE.md` template injected the abstract `DbContext`, which `AddDbContext<AppDbContext>()` never registers, so copy-pasting the recommended registration threw `Unable to resolve service for type 'DbContext'` at runtime. The sample now injects the concrete context (with a note explaining why), the DI section distinguishes the built-in `AddMediantEfCoreUnitOfWork<TContext>()` path from the custom one, and a test mirrors the documented sample verbatim to guard against future drift.


### PR DESCRIPTION
Version bump to 1.3.0 and changelog retitle for release.

## v1.3.0 contents (all merged to main)

### Added
- **Built-in EF Core unit of work** (#137, PR #142) — `AddMediantEfCoreUnitOfWork<TContext>()`; `[Transactional]` works out of the box on the direct-DbContext (no repository) setup, atomically with the outbox.
- **Opt-in savepoint semantics for nested transactions** (#141, PR #146) — `TransactionBehaviorOptions.NestedSavepoints`; the `IUnitOfWork` savepoint API is now live. Default off — join semantics unchanged.

### Fixed
- **Rolled-back entities re-flushed by failure-audit writes on a shared context** (#138, PR #143) — tracker-clearing rollback + regression tests.
- **EF store registrations silently losing to library defaults depending on call order** (#139, PR #144) — `TryAdd` → `Replace`; behavior note in the changelog.
- **EF guide's custom unit-of-work sample could not resolve** (#140, PR #145) — concrete context injection + guide-mirroring test.

413 tests green. Tag `v1.3.0` after merge triggers `release.yml` → nuget.org via Trusted Publishing.