### PR TITLE
release: 1.4.0 — OpenAPI request-side enrichment

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>omercelikdev</Authors>
     <Company>omercelikdev</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Version bump 1.3.0 → 1.4.0 (additive: Accepts on body-bound [HttpEndpoint] mappings + MediantEndpointRequestMetadata). Tag v1.4.0 follows the merge; release.yml publishes via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)