### PR TITLE
chore: migrate references to the qorpe organization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,9 @@ jobs:
         id: nuget-login
         uses: NuGet/login@v1
         with:
+          # The nuget.org account owning the trusted-publishing policy. NOTE: after the repo moved
+          # to the qorpe org, the policy on nuget.org must list repository owner `qorpe` — and if
+          # the package moves to a nuget.org Qorpe organization, change this to that org's name.
           user: omercelikdev
 
       - name: Push to NuGet.org
@@ -110,7 +113,7 @@ jobs:
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
-            --source https://nuget.pkg.github.com/omercelikdev/index.json \
+            --source https://nuget.pkg.github.com/qorpe/index.json \
             --skip-duplicate
         continue-on-error: true
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,17 +13,17 @@
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
     <Version>1.4.0</Version>
-    <Authors>omercelikdev</Authors>
-    <Company>omercelikdev</Company>
+    <Authors>Qorpe</Authors>
+    <Company>Qorpe</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/omercelikdev/mediant</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/omercelikdev/mediant</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/qorpe/mediant</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/qorpe/mediant</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>cqrs;mediator;mediatr-alternative;pipeline;command;query;dotnet;clean-architecture;ddd;domain-events;result-pattern</PackageTags>
     <Description>Enterprise-grade CQRS mediator for .NET — Result pattern, pipeline behaviors, DDD-ready. Free forever.</Description>
-    <Copyright>Copyright (c) omercelikdev 2026</Copyright>
+    <Copyright>Copyright (c) Qorpe 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>https://github.com/omercelikdev/mediant/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/qorpe/mediant/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- Documentation -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![NuGet](https://img.shields.io/nuget/vpre/Mediant.svg)](https://www.nuget.org/packages/Mediant/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Mediant.svg)](https://www.nuget.org/packages/Mediant/)
-[![Build](https://github.com/omercelikdev/mediant/actions/workflows/ci.yml/badge.svg)](https://github.com/omercelikdev/mediant/actions/workflows/ci.yml)
+[![Build](https://github.com/qorpe/mediant/actions/workflows/ci.yml/badge.svg)](https://github.com/qorpe/mediant/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-blue)](https://dotnet.microsoft.com/)
 


### PR DESCRIPTION
Post-transfer sweep: package metadata (`Authors`/`Company`/`RepositoryUrl`/`PackageProjectUrl`), README links, GitHub Packages push target → `qorpe`. The `NUGET_API_KEY` secret survived the transfer; the nuget.org **trusted-publishing policy** still points at the old repo owner and must be updated to `qorpe/mediant` before the next release (inline note added). No version bump — this rides into the next release.