### PR TITLE
chore: publish via the qorpe trusted-publishing policy; v1.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,8 @@ jobs:
         id: nuget-login
         uses: NuGet/login@v1
         with:
-          # The nuget.org account owning the trusted-publishing policy. NOTE: after the repo moved
-          # to the qorpe org, the policy on nuget.org must list repository owner `qorpe` — and if
-          # the package moves to a nuget.org Qorpe organization, change this to that org's name.
-          user: omercelikdev
+          # The nuget.org organization owning the trusted-publishing policy.
+          user: qorpe
 
       - name: Push to NuGet.org
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <!-- Package metadata -->
   <PropertyGroup>
     <!-- Single source of truth for the package version across all projects. -->
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <Authors>Qorpe</Authors>
     <Company>Qorpe</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
`NuGet/login` now acts for the `qorpe` org (policy re-created there after the transfer). v1.4.1 is a metadata-only release: new repository URL, "by qorpe" ownership on the gallery. No code changes.